### PR TITLE
Set title for content field groups

### DIFF
--- a/resources/view/edit/content.html.twig
+++ b/resources/view/edit/content.html.twig
@@ -43,7 +43,7 @@
 			<h2>{{ ('page.' ~ page.type.getName ~ '.' ~ name ~ '.name')|trans }}</h2>
 			<div class="container">
 				{% for i,group in part %}
-					<section class="group" data-colapse>
+					<section class="group" data-colapse data-identifier-field="{{ group.getIdentifierField().getName() }}">
 						<h1 class="title">{{ group.getIdentifierField() }}</h1>
 						<div class="content">
 							{% for field in repeatables[name] %}


### PR DESCRIPTION
Currently I think it's always hardcoded as "Needs a title".

We decided we would pull this from a specific field (defined on the group setup in the page type).

So for "promo", we may set the title field to "Title". The title shown instead of "Needs a title" should be the title.

It should auto-update as it's changed when editing a page.

I believe some code is there to support this.
