### PR TITLE
Change Loader decorators return values for when no models found

### DIFF
--- a/src/Message/Mothership/CMS/Page/Loader.php
+++ b/src/Message/Mothership/CMS/Page/Loader.php
@@ -319,7 +319,7 @@ class Loader
 		$ids = $this->_searcher->getIds();
 
 		if (empty($ids)) {
-			return false;
+			return array();
 		}
 
 		$results = $this->getById($ids);
@@ -550,7 +550,7 @@ class Loader
 		);
 
 		if (0 === count($result)) {
-			return false;
+			return ($this->_returnAsArray) ? array() : false;
 		}
 
 		return $this->_loadPage($result);


### PR DESCRIPTION
When you call a load method for more than one result (`loadByType` etc), an empty array should be returned instead of `false`.

If you ask for a specific result and it is not found, `false` should be returned.
