### PR TITLE
Product image thumbnails should be displayed in the search listing

### DIFF
--- a/resources/view/search/listing.html.twig
+++ b/resources/view/search/listing.html.twig
@@ -11,7 +11,7 @@
 		{% set url = url('ms.cms.frontend', {slug: page.slug|trim('/')}) %}
 		<a href="{{ url }}">
 			{% if page.content.product %}
-				{{ getResizedImage(page.content.product.product.product.image, 135, 200) }}
+				{{ getResizedImage(page.content.product.product.product.image, 109, 131) }}
 			{% endif %}
 			<h2>{{ page.title }}</h2>
 			<span class="url">{{ url }}</span>


### PR DESCRIPTION
https://trello.com/c/lrusIvSL/183-image-thumbs-for-products-should-appear-in-the-search-results
