### PR TITLE
Fix for search breaking when home page appears in results

### DIFF
--- a/resources/view/search/listing.html.twig
+++ b/resources/view/search/listing.html.twig
@@ -8,7 +8,7 @@
 <ul class="search-results">
 {% for page in pages %}
 	<li>
-		{% set url = url('ms.cms.frontend', {slug: page.slug|trim('/')}) %}
+		{% set url = url('ms.cms.frontend', { slug: page.slug|trim('/') ?: '/' }) %}
 		<a href="{{ url }}">
 			{% if page.content.product %}
 				{{ getResizedImage(page.content.product.product.product.image, 109, 131) }}


### PR DESCRIPTION
#### What does this do?

Fixes issue where the search results break if the home page appears in the results
#### How should this be manually tested?

Search for terms that will bring up the home page, such as 'the' and 'home'. The page should not break
#### Related PRs / Issues / Resources?

Fixes https://github.com/messagedigital/union-music-store/issues/157
#### Anything else to add? (Screenshots, background context, etc)

Yes please
