### PR TITLE
Skip search terms under 4 characters

### DIFF
--- a/src/Controller/Frontend.php
+++ b/src/Controller/Frontend.php
@@ -136,7 +136,11 @@ class Frontend extends Controller
 		// Get the current page, default to first.
 		$page = ($this->get('request')->get('page')) ?: 1;
 
-		$pages = $this->get('cms.page.loader')->getBySearchTerms($terms);
+		$pages = $this->get('cms.page.loader')->getBySearchTerms(
+			$terms,
+			1,
+			['min_length' => 4]
+		);
 
 		// Slice the results to get the current page.
 		// $pages = array_slice($pages, ($page - 1) * $perPage, $perPage);

--- a/src/Page/Loader.php
+++ b/src/Page/Loader.php
@@ -325,6 +325,13 @@ class Loader
 	 */
 	public function getBySearchTerms($terms, $page = 1, $options = array())
 	{
+		if (!empty($options['min_length']) && is_int($options['min_length'])) {
+			$this->_searcher->setMinTermLength($options['min_length']);
+		}
+		elseif (!empty($options['min_length'])) {
+			throw new \InvalidArgumentException('`min_length` option must be an integer!');
+		}
+
 		$this->_searcher->setTerms($terms);
 
 		$ids = $this->_searcher->getIds();


### PR DESCRIPTION
#### What does this do?

Remove words under 4 characters from front end searches
#### How should this be manually tested?

On Union, try searching for "the", which should return nothing, but searching a four letter word like "list" should. Then try searching "the august list" and you should still get results
#### Related PRs / Issues / Resources?
#### Anything else to add? (Screenshots, background context, etc)
