### PR TITLE
getByTag() method on page loader

### DIFF
--- a/src/Page/Loader.php
+++ b/src/Page/Loader.php
@@ -311,7 +311,28 @@ class Loader
 		', strtolower($pageType));
 
 		return count($result) ? $this->getById($result->flatten()) : false;
+	}
 
+	/**
+	 * Select a page that has a certain tag
+	 *
+	 * @param $tag
+	 * @return array | bool |Page
+	 */
+	public function getByTag($tag)
+	{
+		$result = $this->_query->run('
+			SELECT
+				page_id
+			FROM
+				page_tag
+			WHERE
+				tag_name = :tag?s
+		', [
+			'tag' => $tag
+		]);
+
+		return count($result) ? $this->getByID($result->flatten()) : false;
 	}
 
 	/**


### PR DESCRIPTION
#### What does this do?

Can load pages using the `getByTag()` method. This pulls page ids from the `page_tag` table and loads any pages with the matching tag. Simple!
#### How should this be manually tested?

Assign a tag to some pages and try and load them using this method.
#### Related PRs / Issues / Resources?
#### Anything else to add? (Screenshots, background context, etc)
