### PR TITLE
Dashboard Page Fix

### DIFF
--- a/src/EventListener.php
+++ b/src/EventListener.php
@@ -137,14 +137,16 @@ class EventListener extends BaseListener implements SubscriberInterface
 		if (count($pageID)) {
 			$page = $this->get('cms.page.loader')->getByID($pageID[0]->page_id);
 
-			$event->addActivity(new Activity(
-				'Last edited page',
-				$page->authorship->updatedAt(),
-				$page->title,
-				$this->get('routing.generator')->generate('ms.cp.cms.edit', [
-					'pageID' => $page->id,
-				], UrlGeneratorInterface::ABSOLUTE_URL)
-			));
+			if($page) {
+				$event->addActivity(new Activity(
+					'Last edited page',
+					$page->authorship->updatedAt(),
+					$page->title,
+					$this->get('routing.generator')->generate('ms.cp.cms.edit', [
+						'pageID' => $page->id,
+					], UrlGeneratorInterface::ABSOLUTE_URL)
+				));
+			}
 		}
 	}
 }


### PR DESCRIPTION
#### What does this do?

Fixes https://github.com/messagedigital/cog-mothership-cp/issues/262 by testing whether the last edited page still exists. We don't load deleted pages, because we don't want to link to the deleted page, which is why I have simple added an if-statement around the adding the activity.
#### How should this be manually tested?

Go to content section, add a page or edit an existing one, then delete the page. Go to `\admin` and see if you get the error. Then checkout this branch and try loading the page again, no exception should now be thrown anymore.
#### Related PRs / Issues / Resources?

Fixes https://github.com/messagedigital/cog-mothership-cp/issues/262
#### Anything else to add? (Screenshots, background context, etc)
