### PR TITLE
Horizontal ellipsis in forms

### DIFF
--- a/src/Controller/ControlPanel/Search.php
+++ b/src/Controller/ControlPanel/Search.php
@@ -53,7 +53,7 @@ class Search extends \Message\Cog\Controller\Controller
 
 		$form->add('terms', 'search', $this->trans('ms.cms.search.label'), array(
 			'attr' => array(
-				'placeholder' => 'Search content&hellip;'
+				'placeholder' => 'Search content…'
 			)
 		));
 


### PR DESCRIPTION
#### What does this do?

Replaces the `&hellip;` with `…` in placeholders and empty_values.
#### How should this be manually tested?

Go to the page and see whether everything is displayed how it should.
#### Related PRs / Issues / Resources?

PR that destroyed everything: https://github.com/messagedigital/cog/pull/387
#### Anything else to add? (Screenshots, background context, etc)
