### PR TITLE
Repopulate contact form on validation failure

### DIFF
--- a/src/Controller/Module/Contact.php
+++ b/src/Controller/Module/Contact.php
@@ -6,11 +6,14 @@ use Message\Cog\Controller\Controller;
 
 class Contact extends Controller
 {
+	const SESSION_NAME  = 'ms.cms.contact_form_data';
+	const CAPTCHA_FIELD = 'captcha';
+
 	public function contact()
 	{
 		$form = $this->createForm(
 			$this->get('form.contact'),
-			null,
+			$this->_getDataFromSession(),
 			['action' => $this->generateUrl('ms.cms.contact.action')]
 		);
 
@@ -24,14 +27,33 @@ class Contact extends Controller
 		$form = $this->createForm($this->get('form.contact'));
 
 		$form->handleRequest();
+		$data = $form->getData();
 
 		if ($form->isValid()) {
-			$data = $form->getData();
 			$this->_sendEmail($data);
 			$this->addFlash('success', $this->trans('ms.cms.contact.success'));
+			$this->get('http.session')->remove(self::SESSION_NAME);
+		}
+		else {
+			$this->get('http.session')->set(self::SESSION_NAME, $data);
 		}
 
 		return $this->redirectToReferer();
+	}
+
+	private function _getDataFromSession()
+	{
+		$data = $this->get('http.session')->get(self::SESSION_NAME);
+
+		if (!$data) {
+			return null;
+		}
+
+		if (array_key_exists(self::CAPTCHA_FIELD, $data)) {
+			unset($data[self::CAPTCHA_FIELD]);
+		}
+
+		return $data;
 	}
 
 	protected function _sendEmail(array $data)


### PR DESCRIPTION
#### What does this do?

Stores saved form data in the session before validation, and removes it if it passes validation. This is so that the post data doesn't disappear in once the user has been redirected to the referer.

It might be an idea to move these into one controller action rather than two, then the browser will automatically repopulate the form without a session store being necessary, but we would still need to make adjustments as the captcha field would need to be cleared.
#### How should this be manually tested?

Make a submission on the contact form on Union and get the captcha wrong. The other fields should repopulate but the catpcha field should be cleared.
#### Related PRs / Issues / Resources?
#### Anything else to add? (Screenshots, background context, etc)
