### PR TITLE
Reverted front end search character limit to char limit set in config

### DIFF
--- a/resources/view/search/listing.html.twig
+++ b/resources/view/search/listing.html.twig
@@ -25,21 +25,3 @@
 {% endfor %}
 </ul>
 {% endblock %}
-
-{#
-<nav>
-	{% if pagination.numPages > 1 %}
-		{% if pagination.page > 1 %}
-			<a href="{{ url('ms.cms.search', {terms: termsString, page: pagination.page-1}) }}">Prev</a>
-		{% endif %}
-
-		{% for i in 1..pagination.numPages %}
-			<a href="{{ url('ms.cms.search', {terms: termsString, page: i}) }}">{{ i }}</a>
-		{% endfor %}
-
-		{% if pagination.page < pagination.numPages %}
-			<a href="{{ url('ms.cms.search', {terms: termsString, page: pagination.page+1}) }}">Next</a>
-		{% endif %}
-	{% endif %}
-</nav>
-#}

--- a/src/Controller/Frontend.php
+++ b/src/Controller/Frontend.php
@@ -144,12 +144,8 @@ class Frontend extends Controller
 
 		$pages = $this->get('cms.page.loader')->getBySearchTerms(
 			$terms,
-			1,
-			['min_length' => 4]
+			1
 		);
-
-		// Slice the results to get the current page.
-		// $pages = array_slice($pages, ($page - 1) * $perPage, $perPage);
 
 		// Log search request.
 		$searchLog            = new SearchLog;


### PR DESCRIPTION
#### What does this do?

The minimum character limit was set to 4 when searching through the front end, although there was a config setting for this already. This PR undoes that, and also deletes a bunch of commented out code

#### How should this be manually tested?

#### Related PRs / Issues / Resources?

#### Anything else to add? (Screenshots, background context, etc)

Yes. This change isn't a BC break, but making this change did break a Mothership site with a view override on the search listing. Reason being that the ternary operator that checks the slug length wasn't there:

```twig
{% set url = url('ms.cms.frontend', {slug: page.slug ?: '/' |trim('/')}) %}
```