### PR TITLE
Blog comments dashboard widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 4.0.1
 
 - Search form displays in sidebar even if no pages exist
+- Cookie trail pages sort by depth
 
 ## 4.0.0
 

--- a/resources/view/modules/dashboard/comments.html.twig
+++ b/resources/view/modules/dashboard/comments.html.twig
@@ -12,8 +12,10 @@
 							<a href="{{ url('ms.cp.cms.edit', {pageID: pPageID}) }}">
 								{{ pages[pPageID].title }}</a>
 							{{ 'ms.cms.dashboard.comment.pending' | transchoice(pCount, {'%count%': pCount}) | raw }}
-							<a href="{{ url('ms.cms.frontend', {slug: pages[pPageID].slug}) }}" class="button small">{{ 'ms.cms.dashboard.comment.view-page' | trans }}</a>
-							<a href="{{ url('ms.cp.cms.edit.comments', {pageID: pPageID} ) }}" class="button small">{{ 'ms.cms.dashboard.comment.review' | trans }}</a>
+							<div>
+								<a href="{{ url('ms.cms.frontend', {slug: pages[pPageID].slug}) }}" class="button small preview">{{ 'ms.cms.dashboard.comment.view-page' | trans }}</a>
+								<a href="{{ url('ms.cp.cms.edit.comments', {pageID: pPageID} ) }}" class="button small comments">{{ 'ms.cms.dashboard.comment.review' | trans }}</a>
+							</div>	
 						</li>
 					{% endfor %}
 				</ul>
@@ -29,8 +31,10 @@
 							<a href="{{ url('ms.cp.cms.edit', {pageID: rPageID}) }}">
 								{{ pages[rPageID].title }}</a>
 							{{ 'ms.cms.dashboard.comment.approved' | transchoice(rCount, {'%count%': rCount}) | raw }}
-							<a href="{{ url('ms.cms.frontend', {slug: pages[rPageID].slug}) }}" class="button small">{{ 'ms.cms.dashboard.comment.view-page' | trans }}</a>
-							<a href="{{ url('ms.cp.cms.edit.comments', {pageID: rPageID} ) }}" class="button small">{{ 'ms.cms.dashboard.comment.review' | trans }}</a>
+							<div>
+								<a href="{{ url('ms.cms.frontend', {slug: pages[rPageID].slug}) }}" class="button small preview">{{ 'ms.cms.dashboard.comment.view-page' | trans }}</a>
+								<a href="{{ url('ms.cp.cms.edit.comments', {pageID: rPageID} ) }}" class="button small comments">{{ 'ms.cms.dashboard.comment.review' | trans }}</a>
+							</div>
 						</li>
 					{% endfor %}
 				</ul>

--- a/resources/view/modules/dashboard/comments.html.twig
+++ b/resources/view/modules/dashboard/comments.html.twig
@@ -1,0 +1,42 @@
+{% if pages %}
+	<div class="module portrait recent-list">
+		<h2 class="title">
+			Comments
+		</h2>
+		<div class="wrap">
+			<h3>Pending comments</h3>
+			{% if pending | length > 0 %}
+				<ul>
+					{% for pPageID, pCount in pending %}
+						<li>
+							<a href="{{ url('ms.cp.cms.edit', {pageID: pPageID}) }}">
+								{{ pages[pPageID].title }}</a>
+							{{ 'ms.cms.dashboard.comment.pending' | transchoice(pCount, {'%count%': pCount}) | raw }}
+							<a href="{{ url('ms.cms.frontend', {slug: pages[pPageID].slug}) }}" class="button small">{{ 'ms.cms.dashboard.comment.view-page' | trans }}</a>
+							<a href="{{ url('ms.cp.cms.edit.comments', {pageID: pPageID} ) }}" class="button small">{{ 'ms.cms.dashboard.comment.review' | trans }}</a>
+						</li>
+					{% endfor %}
+				</ul>
+			{% else %}
+				<p><em>{{ 'ms.cms.dashboard.comment.no-pending' | trans }}</em></p>
+			{% endif %}
+			<hr>
+			<h3>Recently approved</h3>
+			{% if recentlyApproved | length > 0 %}
+				<ul>
+					{% for rPageID, rCount in recentlyApproved %}
+						<li>
+							<a href="{{ url('ms.cp.cms.edit', {pageID: rPageID}) }}">
+								{{ pages[rPageID].title }}</a>
+							{{ 'ms.cms.dashboard.comment.approved' | transchoice(rCount, {'%count%': rCount}) | raw }}
+							<a href="{{ url('ms.cms.frontend', {slug: pages[rPageID].slug}) }}" class="button small">{{ 'ms.cms.dashboard.comment.view-page' | trans }}</a>
+							<a href="{{ url('ms.cp.cms.edit.comments', {pageID: rPageID} ) }}" class="button small">{{ 'ms.cms.dashboard.comment.review' | trans }}</a>
+						</li>
+					{% endfor %}
+				</ul>
+			{% else %}
+				<p><em>{{ 'ms.cms.dashboard.comment.no-approved' | trans }}</em></p>
+			{% endif %}
+		</div>
+	</div>
+{% endif %}

--- a/resources/view/modules/dashboard/comments.html.twig
+++ b/resources/view/modules/dashboard/comments.html.twig
@@ -1,40 +1,34 @@
 {% if pages %}
-	<div class="module portrait recent-list">
-		<h2 class="title">
-			Comments
-		</h2>
+	<div class="module {{ pending | length > 4 ? 'portrait' : 'sq' }} recent-list">
+		<h2 class="title">Pending comments</h2>
+
 		<div class="wrap">
-			<h3>Pending comments</h3>
 			{% if pending | length > 0 %}
 				<ul>
 					{% for pPageID, pCount in pending %}
 						<li>
-							<a href="{{ url('ms.cp.cms.edit', {pageID: pPageID}) }}">
+							<a href="{{ url('ms.cp.cms.edit.comments', {pageID: pPageID} ) }}">
 								{{ pages[pPageID].title }}</a>
 							{{ 'ms.cms.dashboard.comment.pending' | transchoice(pCount, {'%count%': pCount}) | raw }}
-							<div>
-								<a href="{{ url('ms.cms.frontend', {slug: pages[pPageID].slug}) }}" class="button small preview">{{ 'ms.cms.dashboard.comment.view-page' | trans }}</a>
-								<a href="{{ url('ms.cp.cms.edit.comments', {pageID: pPageID} ) }}" class="button small comments">{{ 'ms.cms.dashboard.comment.review' | trans }}</a>
-							</div>	
 						</li>
 					{% endfor %}
 				</ul>
 			{% else %}
 				<p><em>{{ 'ms.cms.dashboard.comment.no-pending' | trans }}</em></p>
 			{% endif %}
-			<hr>
-			<h3>Recently approved</h3>
+		</div>
+	</div>
+	<div class="module {{ recentlyApproved | length > 4 ? 'portrait' : 'sq' }} recent-list">
+		<h2 class="title">Recently approved comments</h2>
+
+		<div class="wrap">
 			{% if recentlyApproved | length > 0 %}
 				<ul>
 					{% for rPageID, rCount in recentlyApproved %}
 						<li>
-							<a href="{{ url('ms.cp.cms.edit', {pageID: rPageID}) }}">
+							<a href="{{ url('ms.cp.cms.edit.comments', {pageID: rPageID} ) }}">
 								{{ pages[rPageID].title }}</a>
 							{{ 'ms.cms.dashboard.comment.approved' | transchoice(rCount, {'%count%': rCount}) | raw }}
-							<div>
-								<a href="{{ url('ms.cms.frontend', {slug: pages[rPageID].slug}) }}" class="button small preview">{{ 'ms.cms.dashboard.comment.view-page' | trans }}</a>
-								<a href="{{ url('ms.cp.cms.edit.comments', {pageID: rPageID} ) }}" class="button small comments">{{ 'ms.cms.dashboard.comment.review' | trans }}</a>
-							</div>
 						</li>
 					{% endfor %}
 				</ul>

--- a/resources/view/modules/dashboard/comments.html.twig
+++ b/resources/view/modules/dashboard/comments.html.twig
@@ -1,40 +1,34 @@
-{% if pages %}
+{% if pending | length > 0 %}
 	<div class="module {{ pending | length > 4 ? 'portrait' : 'sq' }} recent-list">
 		<h2 class="title">Pending comments</h2>
 
 		<div class="wrap scroll">
-			{% if pending | length > 0 %}
-				<ul>
-					{% for pPageID, pCount in pending %}
-						<li>
-							<a href="{{ url('ms.cp.cms.edit.comments', {pageID: pPageID} ) }}">
-								{{ pages[pPageID].title }}</a>
-							{{ 'ms.cms.dashboard.comment.pending' | transchoice(pCount, {'%count%': pCount}) | raw }}
-						</li>
-					{% endfor %}
-				</ul>
-			{% else %}
-				<p><em>{{ 'ms.cms.dashboard.comment.no-pending' | trans }}</em></p>
-			{% endif %}
+			<ul>
+				{% for pPageID, pCount in pending %}
+					<li>
+						<a href="{{ url('ms.cp.cms.edit.comments', {pageID: pPageID} ) }}">
+							{{ pages[pPageID].title }}</a>
+						{{ 'ms.cms.dashboard.comment.pending' | transchoice(pCount, {'%count%': pCount}) | raw }}
+					</li>
+				{% endfor %}
+			</ul>
 		</div>
 	</div>
+{% endif %}
+{% if recentlyApproved | length > 0 %}
 	<div class="module {{ recentlyApproved | length > 4 ? 'portrait' : 'sq' }} recent-list">
 		<h2 class="title">Recently approved comments</h2>
 
 		<div class="wrap scroll">
-			{% if recentlyApproved | length > 0 %}
-				<ul>
-					{% for rPageID, rCount in recentlyApproved %}
-						<li>
-							<a href="{{ url('ms.cp.cms.edit.comments', {pageID: rPageID} ) }}">
-								{{ pages[rPageID].title }}</a>
-							{{ 'ms.cms.dashboard.comment.approved' | transchoice(rCount, {'%count%': rCount}) | raw }}
-						</li>
-					{% endfor %}
-				</ul>
-			{% else %}
-				<p><em>{{ 'ms.cms.dashboard.comment.no-approved' | trans }}</em></p>
-			{% endif %}
+			<ul>
+				{% for rPageID, rCount in recentlyApproved %}
+					<li>
+						<a href="{{ url('ms.cp.cms.edit.comments', {pageID: rPageID} ) }}">
+							{{ pages[rPageID].title }}</a>
+						{{ 'ms.cms.dashboard.comment.approved' | transchoice(rCount, {'%count%': rCount}) | raw }}
+					</li>
+				{% endfor %}
+			</ul>
 		</div>
 	</div>
 {% endif %}

--- a/src/Blog/Comment.php
+++ b/src/Blog/Comment.php
@@ -318,6 +318,18 @@ class Comment
 	}
 
 	/**
+	 * @return \Message\Cog\ValueObject\DateTimeImmutable | null
+	 */
+	public function getUpdatedAt()
+	{
+		if ($updatedAt = $this->_authorship->updatedAt()) {
+			return $updatedAt;
+		}
+
+		return $this->getCreatedAt();
+	}
+
+	/**
 	 * @param $updatedAt
 	 *
 	 * @return $this

--- a/src/Blog/CommentBuilder.php
+++ b/src/Blog/CommentBuilder.php
@@ -39,8 +39,14 @@ class CommentBuilder
 	 */
 	private $_request;
 
+	/**
+	 * @var ContentValidator
+	 */
 	private $_contentValidator;
 
+	/**
+	 * @var UserGroupLoader
+	 */
 	private $_userGroupLoader;
 
 	/**

--- a/src/Blog/CommentBuilder.php
+++ b/src/Blog/CommentBuilder.php
@@ -91,6 +91,15 @@ class CommentBuilder
 		return $comment;
 	}
 
+	/**
+	 * Set the status of the comment, depending on the configuration of the blog post, and who is making the comment.
+	 * A super admin's comment will always be approved right away
+	 *
+	 * @param Comment $comment
+	 * @param Content $content
+	 *
+	 * @return Comment
+	 */
 	private function _setStatus(Comment $comment, Content $content)
 	{
 		if (!$this->_user instanceof AnonymousUser) {

--- a/src/Blog/CommentBuilder.php
+++ b/src/Blog/CommentBuilder.php
@@ -7,7 +7,9 @@ use Message\Mothership\CMS\Page\Content;
 use Message\Mothership\User\Avatar;
 
 use Message\User\UserInterface;
+use Message\User\AnonymousUser;
 use Message\User\User;
+use Message\User\Group\Loader as UserGroupLoader;
 
 use Message\Cog\HTTP\Request;
 
@@ -37,16 +39,21 @@ class CommentBuilder
 	 */
 	private $_request;
 
+	private $_contentValidator;
+
+	private $_userGroupLoader;
+
 	/**
 	 * @param UserInterface $user
 	 * @param Request $request
 	 * @param ContentValidator $contentValidator
 	 */
-	public function __construct(UserInterface $user, Request $request, ContentValidator $contentValidator)
+	public function __construct(UserInterface $user, Request $request, ContentValidator $contentValidator, UserGroupLoader $userGroupLoader)
 	{
 		$this->_user             = $user;
 		$this->_request          = $request;
 		$this->_contentValidator = $contentValidator;
+		$this->_userGroupLoader  = $userGroupLoader;
 	}
 
 	/**
@@ -67,18 +74,40 @@ class CommentBuilder
 		$comment->setPageID($pageID);
 		$comment->setName($data[self::NAME]);
 		$comment->setEmail($data[self::EMAIL]);
+
 		if (!empty($data[self::WEBSITE])) {
 			$comment->setWebsite($data[self::WEBSITE]);
 		}
+
 		$comment->setContent($data[self::COMMENT]);
 		$comment->setIpAddress($this->_request->getClientIp());
-		$allowed = $content->{ContentOptions::COMMENTS}->{ContentOptions::ALLOW_COMMENTS}->getValue();
-
-		$comment->setStatus($allowed === ContentOptions::APPROVE ? Statuses::PENDING : Statuses::APPROVED);
 
 		if ($this->_user instanceof User) {
 			$comment->setUserID($this->_user->id);
 		}
+
+		$this->_setStatus($comment, $content);
+
+		return $comment;
+	}
+
+	private function _setStatus(Comment $comment, Content $content)
+	{
+		if (!$this->_user instanceof AnonymousUser) {
+			$userGroups = $this->_userGroupLoader->getByUser($this->_user);
+
+			foreach ($userGroups as $group) {
+				if ($group->getName() === 'ms-super-admin') {
+					$comment->setStatus(Statuses::APPROVED);
+
+					return $comment;
+				}
+			}
+		}
+
+		$allowed = $content->{ContentOptions::COMMENTS}->{ContentOptions::ALLOW_COMMENTS}->getValue();
+
+		$comment->setStatus($allowed === ContentOptions::APPROVE ? Statuses::PENDING : Statuses::APPROVED);
 
 		return $comment;
 	}

--- a/src/Blog/CommentLoader.php
+++ b/src/Blog/CommentLoader.php
@@ -79,6 +79,16 @@ class CommentLoader
 		return new CommentCollection($comments);
 	}
 
+	/**
+	 * Load all comments with one or or one of many statuses
+	 *
+	 * @param array | string $statuses           Status(es) to check for. Can be either a string or an array
+	 *                                           but all statuses must be valid
+	 * @param string $order                      Order to load in, must be either ASC or DESC
+	 * @throws \InvalidArgumentException         Throws exception if $order is invalid
+	 *
+	 * @return CommentCollection
+	 */
 	public function getByStatus($statuses, $order = 'ASC')
 	{
 		$statuses = $this->_parseStatuses((array) $statuses);

--- a/src/Blog/CommentLoader.php
+++ b/src/Blog/CommentLoader.php
@@ -59,7 +59,7 @@ class CommentLoader
 	 */
 	public function getByPage($pageID, array $statuses = null)
 	{
-		$statuses = $this->_parseTypes($statuses);
+		$statuses = $this->_parseStatuses($statuses);
 
 		if (!is_numeric($pageID)) {
 			throw new \InvalidArgumentException('Page ID must be a numeric, ' . gettype($pageID) . ' given');
@@ -71,6 +71,25 @@ class CommentLoader
 			->where('page_id = :pageID?i', ['pageID' => $pageID])
 			->where('status IN (?js)', [$statuses])
 			->orderBy('created_at ASC')
+			->getQuery()
+			->run()
+			->bindTo('\\Message\\Mothership\\CMS\\Blog\\Comment')
+		;
+
+		return new CommentCollection($comments);
+	}
+
+	public function getByStatus($statuses, $order = 'ASC')
+	{
+		$statuses = $this->_parseStatuses((array) $statuses);
+
+		if (!in_array($order, ['ASC', 'DESC'])) {
+			throw new \InvalidArgumentException('Order must be either `ASC` or `DESC`');
+		}
+
+		$comments = (array) $this->_getSelect()
+			->where('status IN (?js)', [$statuses])
+			->orderBy('created_at ' . $order)
 			->getQuery()
 			->run()
 			->bindTo('\\Message\\Mothership\\CMS\\Blog\\Comment')
@@ -101,7 +120,7 @@ class CommentLoader
 	 *
 	 * @return array
 	 */
-	private function _parseTypes(array $statuses = null)
+	private function _parseStatuses(array $statuses = null)
 	{
 		if (null === $statuses) {
 			return array_keys($this->_statuses->getStatuses());

--- a/src/Blog/Dashboard/DashboardLoader.php
+++ b/src/Blog/Dashboard/DashboardLoader.php
@@ -6,6 +6,17 @@ use Message\Mothership\CMS\Page;
 use Message\Mothership\CMS\PageType;
 use Message\Mothership\CMS\Blog;
 
+/**
+ * Class DashboardLoader
+ * @package Message\Mothership\CMS\Blog\Dashboard
+ *
+ * @author Thomas Marchant <thomas@mothership.ec>
+ *
+ * Class for loading the appropriate data to display on the comment dashboard panel:
+ * - Pending comments
+ * - Comments approved within the last 7 days
+ * - Pages with either pending comments or recently approved comments
+ */
 class DashboardLoader
 {
 	/**
@@ -18,13 +29,35 @@ class DashboardLoader
 	 */
 	private $_pageLoader;
 
+	/**
+	 * @var null | array
+	 */
 	private $_pages;
 
+	/**
+	 * Array containing an array of page IDs with pending comment counts, and an array of page IDs with recently
+	 * approved comment counts
+	 *
+	 * @var array
+	 */
 	private $_counts;
 
+	/**
+	 * @var bool
+	 */
 	private $_loaded = false;
+
+	/**
+	 * The unix timestamp for 00:00 7 days ago
+	 *
+	 * @var int
+	 */
 	private $_aWeekAgo;
-	private $_pageIDs;
+
+	/**
+	 * @var array
+	 */
+	private $_pageIDs = [];
 
 	public function __construct(Blog\CommentLoader $commentLoader, Page\Loader $pageLoader, PageType\Collection $pageTypes)
 	{
@@ -32,43 +65,95 @@ class DashboardLoader
 		$this->_pageLoader    = $pageLoader;
 		$this->_pageTypes     = $pageTypes;
 
-		// Set to bypass all loading if no page types extend AbstractBlog
-		$this->_blogInstalled();
+		// Set to bypass all loading if there is no blog
+		if (!$this->_blogInstalled()) {
+			$this->_loadEmpty();
+		}
 	}
 
+	/**
+	 * Get an array of pages that have either pending comments or recently approved comments, with page IDs for keys
+	 *
+	 * @return array
+	 */
 	public function getPages()
 	{
 		$this->_load();
 
 		if (null === $this->_pages) {
-			$this->_pages = $this->_pageLoader->getByID($this->_pageIDs);
+			$pages = $this->_pageLoader->getByID($this->_pageIDs);
+			$this->_pages = [];
+
+			foreach ($pages as $page) {
+				$this->_pages[$page->id] = $page;
+			}
 		}
 
 		return $this->_pages;
 	}
 
-	public function getPendingComments()
+	/**
+	 * Get the number of pending comments for each page
+	 *
+	 * @return array
+	 */
+	public function getPendingCounts()
 	{
 		$this->_load();
 
 		return $this->_counts[Blog\Statuses::PENDING];
 	}
 
-	public function getRecentlyApprovedComments()
+	/**
+	 * Get the number of recently approved comments for each page
+	 *
+	 * @return array
+	 */
+	public function getRecentlyApprovedCounts()
 	{
 		$this->_load();
 
 		return $this->_counts[Blog\Statuses::APPROVED];
 	}
 
+	/**
+	 * Check to see if any page types extend AbstractBog
+	 *
+	 * @return bool
+	 */
 	private function _blogInstalled()
 	{
 		foreach ($this->_pageTypes as $pageType) {
 			if ($pageType instanceof PageType\AbstractBlog) {
-				return;
+				return true;
 			}
 		}
 
+		return false;
+	}
+
+	/**
+	 * Load all comment counts
+	 */
+	private function _load()
+	{
+		if (false === $this->_loaded) {
+			$comments = $this->_commentLoader->getByStatus([
+				Blog\Statuses::PENDING,
+				Blog\Statuses::APPROVED
+			], 'DESC');
+
+			$this->_counts = $this->_countCommentsByPage($comments);
+
+			$this->_loaded = true;
+		}
+	}
+
+	/**
+	 * Bypass loading and set all counts to empty
+	 */
+	private function _loadEmpty()
+	{
 		$this->_loaded = true;
 
 		$this->_counts = [
@@ -79,21 +164,14 @@ class DashboardLoader
 		$this->_pages = [];
 	}
 
-	private function _load()
-	{
-		if (false === $this->_loaded) {
-			$comments = $this->_commentLoader->getByStatus([
-				Blog\Statuses::PENDING,
-				Blog\Statuses::APPROVED
-			]);
-
-			$this->_counts = $this->_countPendingByPage($comments);
-
-			$this->_loaded = true;
-		}
-	}
-
-	private function _countPendingByPage(Blog\CommentCollection $comments)
+	/**
+	 * Loop through comments and count the amount of comments for each page, sorting by their status and age
+	 *
+	 * @param Blog\CommentCollection $comments
+	 *
+	 * @return array
+	 */
+	private function _countCommentsByPage(Blog\CommentCollection $comments)
 	{
 		if (null === $this->_counts) {
 			$pendingCommentCount = [];
@@ -101,9 +179,9 @@ class DashboardLoader
 
 			foreach ($comments as $comment) {
 				if ($comment->getStatus() === Blog\Statuses::PENDING) {
-					$this->_addCommentToCount($comment, $pendingCommentCount);
-				} elseif ($comment->getStatus === Blog\Statuses::APPROVED && $this->_commentFromThisWeek($comment)) {
-					$this->_addCommentToCount($comment, $activeCommentCount);
+					$this->_incrementCommentCount($comment, $pendingCommentCount);
+				} elseif ($comment->getStatus() === Blog\Statuses::APPROVED && $this->_commentFromThisWeek($comment)) {
+					$this->_incrementCommentCount($comment, $activeCommentCount);
 				}
 			}
 
@@ -116,7 +194,14 @@ class DashboardLoader
 		return $this->_counts;
 	}
 
-	private function _addCommentToCount(Blog\Comment $comment, array &$count)
+	/**
+	 * Assign comment to a page comment count
+	 *
+	 * @param Blog\Comment $comment
+	 *
+	 * @param array $count
+	 */
+	private function _incrementCommentCount(Blog\Comment $comment, array &$count)
 	{
 		if (!array_key_exists($comment->getPageID(), $count)) {
 			$count[$comment->getPageID()] = 0;
@@ -128,15 +213,29 @@ class DashboardLoader
 		$count[$comment->getPageID()]++;
 	}
 
+	/**
+	 * Check to see if a comment was updated within the last seven days
+	 *
+	 * @param Blog\Comment $comment
+	 *
+	 * @return bool
+	 */
 	private function _commentFromThisWeek(Blog\Comment $comment)
 	{
 		if (null === $this->_aWeekAgo) {
 			$this->_aWeekAgo = $this->_getDayTimestamp(new \DateTime('-1 week'));
 		}
 
-		return $this->_getDayTimestamp($comment->getCreatedAt()) >= $this->_aWeekAgo;
+		return $this->_getDayTimestamp($comment->getUpdatedAt()) >= $this->_aWeekAgo;
 	}
 
+	/**
+	 * Get timestamp for 00:00 on a \DateTime
+	 *
+	 * @param \DateTime $datetime
+	 *
+	 * @return int
+	 */
 	private function _getDayTimestamp(\DateTime $datetime)
 	{
 		$datetime->format('Y-m-d');

--- a/src/Blog/Dashboard/DashboardLoader.php
+++ b/src/Blog/Dashboard/DashboardLoader.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Message\Mothership\CMS\Blog\Dashboard;
+
+use Message\Mothership\CMS\Page;
+use Message\Mothership\CMS\PageType;
+use Message\Mothership\CMS\Blog;
+
+class DashboardLoader
+{
+	/**
+	 * @var Blog\CommentLoader
+	 */
+	private $_commentLoader;
+
+	/**
+	 * @var Page\Loader
+	 */
+	private $_pageLoader;
+
+	private $_pages;
+
+	private $_counts;
+
+	private $_loaded = false;
+	private $_aWeekAgo;
+	private $_pageIDs;
+
+	public function __construct(Blog\CommentLoader $commentLoader, Page\Loader $pageLoader, PageType\Collection $pageTypes)
+	{
+		$this->_commentLoader = $commentLoader;
+		$this->_pageLoader    = $pageLoader;
+		$this->_pageTypes     = $pageTypes;
+
+		// Set to bypass all loading if no page types extend AbstractBlog
+		$this->_blogInstalled();
+	}
+
+	public function getPages()
+	{
+		$this->_load();
+
+		if (null === $this->_pages) {
+			$this->_pages = $this->_pageLoader->getByID($this->_pageIDs);
+		}
+
+		return $this->_pages;
+	}
+
+	public function getPendingComments()
+	{
+		$this->_load();
+
+		return $this->_counts[Blog\Statuses::PENDING];
+	}
+
+	public function getRecentlyApprovedComments()
+	{
+		$this->_load();
+
+		return $this->_counts[Blog\Statuses::APPROVED];
+	}
+
+	private function _blogInstalled()
+	{
+		foreach ($this->_pageTypes as $pageType) {
+			if ($pageType instanceof PageType\AbstractBlog) {
+				return;
+			}
+		}
+
+		$this->_loaded = true;
+
+		$this->_counts = [
+			Blog\Statuses::PENDING  => [],
+			Blog\Statuses::APPROVED => [],
+		];
+
+		$this->_pages = [];
+	}
+
+	private function _load()
+	{
+		if (false === $this->_loaded) {
+			$comments = $this->_commentLoader->getByStatus([
+				Blog\Statuses::PENDING,
+				Blog\Statuses::APPROVED
+			]);
+
+			$this->_counts = $this->_countPendingByPage($comments);
+
+			$this->_loaded = true;
+		}
+	}
+
+	private function _countPendingByPage(Blog\CommentCollection $comments)
+	{
+		if (null === $this->_counts) {
+			$pendingCommentCount = [];
+			$activeCommentCount  = [];
+
+			foreach ($comments as $comment) {
+				if ($comment->getStatus() === Blog\Statuses::PENDING) {
+					$this->_addCommentToCount($comment, $pendingCommentCount);
+				} elseif ($comment->getStatus === Blog\Statuses::APPROVED && $this->_commentFromThisWeek($comment)) {
+					$this->_addCommentToCount($comment, $activeCommentCount);
+				}
+			}
+
+			$this->_counts = [
+				Blog\Statuses::PENDING  => $pendingCommentCount,
+				Blog\Statuses::APPROVED => $activeCommentCount,
+			];
+		}
+
+		return $this->_counts;
+	}
+
+	private function _addCommentToCount(Blog\Comment $comment, array &$count)
+	{
+		if (!array_key_exists($comment->getPageID(), $count)) {
+			$count[$comment->getPageID()] = 0;
+		}
+		if (!in_array($comment->getPageID(), $this->_pageIDs)) {
+			$this->_pageIDs[] = $comment->getPageID();
+		}
+
+		$count[$comment->getPageID()]++;
+	}
+
+	private function _commentFromThisWeek(Blog\Comment $comment)
+	{
+		if (null === $this->_aWeekAgo) {
+			$this->_aWeekAgo = $this->_getDayTimestamp(new \DateTime('-1 week'));
+		}
+
+		return $this->_getDayTimestamp($comment->getCreatedAt()) >= $this->_aWeekAgo;
+	}
+
+	private function _getDayTimestamp(\DateTime $datetime)
+	{
+		$datetime->format('Y-m-d');
+
+		return $datetime->getTimestamp();
+	}
+}

--- a/src/Bootstrap/Services.php
+++ b/src/Bootstrap/Services.php
@@ -145,7 +145,7 @@ class Services implements ServicesInterface
 		};
 
 		$services['cms.blog.comment_builder'] = $services->factory(function($c) {
-			return new CMS\Blog\CommentBuilder($c['user.current'], $c['request'], $c['cms.blog.content_validator']);
+			return new CMS\Blog\CommentBuilder($c['user.current'], $c['request'], $c['cms.blog.content_validator'], $c['user.group.loader']);
 		});
 
 		$services['cms.blog.comment_loader'] = function($c) {
@@ -169,7 +169,7 @@ class Services implements ServicesInterface
 		};
 
 		$services['cms.blog.comment_dashboard_loader'] = function($c) {
-			return new CMS\Blog\Dashboard\DashboardLoader($c['cms.blog.comment_loader'], $c['cms.blog.page_loader'], $c['cms.page.types']);
+			return new CMS\Blog\Dashboard\DashboardLoader($c['cms.blog.comment_loader'], $c['cms.page.loader'], $c['cms.page.types']);
 		};
 
 		$services->extend('field.collection', function($fields, $c) {

--- a/src/Bootstrap/Services.php
+++ b/src/Bootstrap/Services.php
@@ -168,6 +168,10 @@ class Services implements ServicesInterface
 			return new CMS\Blog\Statuses;
 		};
 
+		$services['cms.blog.comment_dashboard_loader'] = function($c) {
+			return new CMS\Blog\Dashboard\DashboardLoader($c['cms.blog.comment_loader'], $c['cms.blog.page_loader'], $c['cms.page.types']);
+		};
+
 		$services->extend('field.collection', function($fields, $c) {
 			$fields->add(new \Message\Mothership\CMS\FieldType\Link($c['cms.page.loader']));
 

--- a/src/Controller/Module/Dashboard/BlogComments.php
+++ b/src/Controller/Module/Dashboard/BlogComments.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Message\Mothership\CMS\Controller\Module\Dashboard;
+
+use Message\Mothership\CMS\Blog;
+use Message\Cog\Controller\Controller;
+
+class BlogComments extends Controller
+{
+	public function index()
+	{
+		$pending          = $this->get('cms.blog.comment_dashboard_loader')->getPendingComments();
+		$recentlyApproved = $this->get('cms.blog.comment_dashboard_loader')->getRecentlyApprovedComments();
+
+		$pages = (count($pending) && count($recentlyApproved)) ? $this->get('cms.blog.comment_dashboard_loader')->getPages() : null;
+
+		return $this->render('Message:Mothership:CMS::modules:dashboard:comments', [
+			'pending'          => $pending,
+			'recentlyApproved' => $recentlyApproved,
+			'pages'            => $pages,
+		]);
+	}
+}

--- a/src/Controller/Module/Dashboard/BlogComments.php
+++ b/src/Controller/Module/Dashboard/BlogComments.php
@@ -9,10 +9,10 @@ class BlogComments extends Controller
 {
 	public function index()
 	{
-		$pending          = $this->get('cms.blog.comment_dashboard_loader')->getPendingComments();
-		$recentlyApproved = $this->get('cms.blog.comment_dashboard_loader')->getRecentlyApprovedComments();
+		$pending          = $this->get('cms.blog.comment_dashboard_loader')->getPendingCounts();
+		$recentlyApproved = $this->get('cms.blog.comment_dashboard_loader')->getRecentlyApprovedCounts();
 
-		$pages = (count($pending) && count($recentlyApproved)) ? $this->get('cms.blog.comment_dashboard_loader')->getPages() : null;
+		$pages = ($pending || $recentlyApproved) ? $this->get('cms.blog.comment_dashboard_loader')->getPages() : null;
 
 		return $this->render('Message:Mothership:CMS::modules:dashboard:comments', [
 			'pending'          => $pending,

--- a/src/Controller/Module/Dashboard/CMSSummary.php
+++ b/src/Controller/Module/Dashboard/CMSSummary.php
@@ -17,8 +17,6 @@ class CMSSummary extends Controller
 	/**
 	 * Get recently updated pages.
 	 *
-	 * @todo Add recently deleted
-	 *
 	 * @return Message\Cog\HTTP\Response
 	 */
 	public function index()

--- a/src/EventListener.php
+++ b/src/EventListener.php
@@ -92,13 +92,6 @@ class EventListener extends BaseListener implements SubscriberInterface
 	public function pageNotFound(GetResponseForExceptionEvent $event)
 	{
 		$exception = $event->getException();
-
-		// if ($exception instanceof HttpException && $exception->getStatusCode() == 404 && in_array('ms.cp', $event->getRequest()->get('_route_collections'))) {
-		// 	$this->_services['http.session']->getFlashBag()->add('error', $exception->getMessage());
-		// 	$event->setResponse(new RedirectResponse(
-		// 		$this->_services['routing.generator']->generate('ms.cp.cms.dashboard')
-		// 	));
-		// };
 	}
 
 	/**
@@ -109,6 +102,7 @@ class EventListener extends BaseListener implements SubscriberInterface
 	public function buildDashboardIndex(DashboardEvent $event)
 	{
 		$event->addReference('Message:Mothership:CMS::Controller:Module:Dashboard:CMSSummary#index');
+		$event->addReference('Message:Mothership:CMS::Controller:Module:Dashboard:BlogComments#index');
 	}
 
 	/**
@@ -119,6 +113,7 @@ class EventListener extends BaseListener implements SubscriberInterface
 	public function buildDashboardContent(DashboardEvent $event)
 	{
 		$event->addReference('Message:Mothership:CMS::Controller:Module:Dashboard:CMSSummary#index');
+		$event->addReference('Message:Mothership:CMS::Controller:Module:Dashboard:BlogComments#index');
 	}
 
 	/**

--- a/translations/en.yml
+++ b/translations/en.yml
@@ -35,6 +35,13 @@ ms.cms:
     remove: Remove this %name%
   dashboard:
     page-title: Dashboard
+    comment:
+      pending: "has <strong>%count%</strong> pending comment|has <strong>%count%</strong> pending comments"
+      no-pending: No pending comments
+      approved: "has <strong>%count%</strong> recently approved comment|has <strong>%count%</strong> recently approved comments"
+      no-approved: No recently approved comments
+      view-page: View page
+      review: Review
   edit:
     title:
       label: Title

--- a/translations/en.yml
+++ b/translations/en.yml
@@ -36,9 +36,9 @@ ms.cms:
   dashboard:
     page-title: Dashboard
     comment:
-      pending: "has <strong>%count%</strong> pending comment|has <strong>%count%</strong> pending comments"
+      pending: has <strong>%count%</strong> pending comment|has <strong>%count%</strong> pending comments
       no-pending: No pending comments
-      approved: "has <strong>%count%</strong> recently approved comment|has <strong>%count%</strong> recently approved comments"
+      approved: has <strong>%count%</strong> recently approved comment|has <strong>%count%</strong> recently approved comments
       no-approved: No recently approved comments
       view-page: View page
       review: Review


### PR DESCRIPTION
#### What does this do?

Adds a dashboard widget showing basic information about comments. It will do the following:

+ Only show up if there is a page type that extends `AbstractBlog` 
+ Will display a list of pages that have comments with a status of `pending`
+ Will display a list of pages that have comments that have been approved within the last 7 days
+ All pages that appear in lists will have links to view the page, and to review the comments

Additional functionality:

+ Automatic comment approval for super admins
+ Added `getUpdatedAt()` method to Comment object
+ Added `getByStatus()` method to `CommentLoader`

Potential BC break:

+ The `CommentBuilder` class has had an extra parameter added to its __construct() method. I figure this is fairly safe since the number of people use Mothership is still low, it's accessed via the service container, and it's not the kind of class that people are going to be extending,

#### How should this be manually tested?

+ Check that pending and approved comments show up in the correct lists
+ Check that approved comments approved longer than 7 days ago do not show up in the lists
+ Check that CMS sites with no blog page types do not have this dashboard panel
+ Check that super admin comments are automatically approved
+ Check that non-super admin comments are not automatically approved, unless the blog post is configured as such
+ Check that pluralization is accurate

#### Related PRs / Issues / Resources?

#### Anything else to add? (Screenshots, background context, etc)