### PR TITLE
Check for and prevent malformed data when moving pages

### DIFF
--- a/resources/assets/js/page-edit.js
+++ b/resources/assets/js/page-edit.js
@@ -1,0 +1,14 @@
+$(document).ready(function() {
+	var parentField = $('#attributes_parent'),
+		parentVal = parentField.val(),
+		siblingField = $('#attributes_siblings')
+	;
+
+	parentField.change(function () {
+		if (parentField.val() !== parentVal) {
+			siblingField.attr('disabled', 'disabled');
+		} else {
+			siblingField.removeAttr('disabled');
+		}
+	})
+});

--- a/resources/view/edit.html.twig
+++ b/resources/view/edit.html.twig
@@ -1,5 +1,19 @@
 {% extends 'Message:Mothership:ControlPanel::_templates/left_sidebar' %}
 
+{% block javascripts %}
+	{{ parent() }}
+
+	{% javascripts
+		'@Message:Mothership:CMS::resources/assets/js/page-edit.js'
+
+		output='/assets/js/ms_cms.js'
+		filter='?jsmin'
+	%}
+		<script src="{{ asset_url }}"></script>
+	{% endjavascripts %}
+
+{% endblock %}
+
 {% block sidebar %}
 	{{ render(controller('Message:Mothership:CMS::Controller:ControlPanel:Sidebar#index', {'currentPageID':page.id}))}}
 {% endblock %}

--- a/src/Controller/ControlPanel/Edit.php
+++ b/src/Controller/ControlPanel/Edit.php
@@ -250,10 +250,7 @@ class Edit extends \Message\Cog\Controller\Controller
 			$this->addFlash('success', $this->trans('ms.cms.feedback.edit.attributes.success'));
 		}
 
-		return $this->render('::edit/attributes', array(
-			'page' => $page,
-			'form' => $form,
-		));
+		return $this->redirectToReferer();
 	}
 
 	/**

--- a/src/Controller/ControlPanel/Edit.php
+++ b/src/Controller/ControlPanel/Edit.php
@@ -3,13 +3,12 @@
 namespace Message\Mothership\CMS\Controller\ControlPanel;
 
 use Message\Cog\Field;
+use Message\Cog\DB\NestedSetException;
 
 use Message\Mothership\CMS\Page\Authorisation;
 use Message\Mothership\CMS\Page\Page;
 use Message\Mothership\CMS\Page\Content;
-use Message\Cog\Field\Form;
-use Message\Cog\Field\Factory;
-use Message\Cog\Field\RepeatableContainer;
+use Message\Mothership\CMS\Page\Exception\PageEditException;
 
 use Message\Cog\ValueObject\Slug;
 use Message\Mothership\FileManager\File;
@@ -22,6 +21,8 @@ class Edit extends \Message\Cog\Controller\Controller
 	 * Index for editing, this just redirects to the content edit screen.
 	 *
 	 * @param int $pageID The page ID
+	 *
+	 * @return Response
 	 */
 	public function index($pageID)
 	{
@@ -68,6 +69,8 @@ class Edit extends \Message\Cog\Controller\Controller
 	 * POST action for updating the page's title.
 	 *
 	 * @param int $pageID The page ID
+	 *
+	 * @return Response
 	 */
 	public function updateTitle($pageID)
 	{
@@ -93,6 +96,8 @@ class Edit extends \Message\Cog\Controller\Controller
 	 * Render the content form.
 	 *
 	 * @param int $pageID The page ID
+	 *
+	 * @return Response
 	 */
 	public function content($pageID, $form = null)
 	{
@@ -139,6 +144,8 @@ class Edit extends \Message\Cog\Controller\Controller
 	 * Render the attributes form.
 	 *
 	 * @param int $pageID The page ID
+	 *
+	 * @return Response
 	 */
 	public function attributes($pageID)
 	{
@@ -166,6 +173,8 @@ class Edit extends \Message\Cog\Controller\Controller
 	 * @param  int 		$pageID 	The pageID of the page
 	 * @param  string 	$slug   	The slug to remove from history and update
 	 *                          	the given page
+	 *
+	 * @return Response
 	 */
 	public function forceSlugAction($pageID, $slug)
 	{
@@ -191,6 +200,8 @@ class Edit extends \Message\Cog\Controller\Controller
 	 *        	already exist in that new section.
 	 *
 	 * @param  	int 	$pageID 	id of the Page object to be loaded and updated
+	 *
+	 * @return Response
 	 */
 	public function attributesAction($pageID)
 	{
@@ -202,19 +213,28 @@ class Edit extends \Message\Cog\Controller\Controller
 			$data['parent'] = isset($data['parent']) ? $data['parent'] : 0;
 			// If the parentID != the submitted parent OR the parent is false
 			// (as it's root) and the submitted parent is not 0 (root)
-			if (($parent && $parent->id != $data['parent']) || (!$parent && $data['parent'] != 0)) {
-				if ($this->get('cms.page.edit')->changeParent($pageID, $data['parent'])) {
-					$this->addFlash('success', 'Parent successully changed');
-				} else {
-					$this->addFlash('error', 'The page could not be moved to a new position');
-				}
-			}
 
-			if (!is_null($data['siblings']) && $data['siblings'] >= 0) {
-				$index = $data['siblings'];
-				if (!$this->get('cms.page.edit')->changeOrder($page, $index)) {
-					$this->addFlash('error', 'The page could not be moved to a new position');
+			try {
+				if (($parent && $parent->id != $data['parent']) || (!$parent && $data['parent'] != 0)) {
+					if ($this->get('cms.page.edit')->changeParent($pageID, $data['parent'])) {
+						$this->addFlash('success', $this->trans('ms.cms.feedback.edit.attributes.parent.success'));
+					} else {
+						$this->addFlash('error', $this->trans('ms.cms.feedback.edit.attributes.parent.failure'));
+					}
 				}
+
+				if (!is_null($data['siblings']) && $data['siblings'] >= 0) {
+					$index = $data['siblings'];
+					if (!$this->get('cms.page.edit')->changeOrder($page, $index)) {
+						$this->addFlash('error', $this->trans('ms.cms.feedback.edit.attributes.order.failure'));
+					}
+				}
+			} catch (NestedSetException $e) {
+				$this->addFlash('error', $this->trans('ms.cms.feedback.edit.attributes.nested-set.error', ['%error%' => $e->getMessage()]));
+
+				return $this->redirectToReferer();
+			} catch (PageEditException $e) {
+				$this->addFlash('error', $this->trans('ms.cms.feedback.edit.attributes.order.failure'));
 			}
 
 			$page = $this->_updateSlug($page, $data['slug']);
@@ -229,7 +249,6 @@ class Edit extends \Message\Cog\Controller\Controller
 			$page = $this->get('cms.page.edit')->save($page);
 			$this->addFlash('success', $this->trans('ms.cms.feedback.edit.attributes.success'));
 		}
-
 
 		return $this->render('::edit/attributes', array(
 			'page' => $page,

--- a/src/Page/Edit.php
+++ b/src/Page/Edit.php
@@ -273,41 +273,41 @@ class Edit implements TransactionalInterface
 	 * @param  Page 	$page 				The Page object of the page we are
 	 *                         				going to move
 	 * @param  int  	$index				The position index to move to.
+	 *
+ 	 * @return bool
 	 */
 	public function changeOrder(Page $page, $index)
 	{
 		// This is important as we add 1 to the key
-		try {
+		$siblings = $this->_loader
+			->getSiblings($page);
+		// We minus one here as we have to add one in the controller so 0 is
+		// the move to top option.
+		$nearestSibling = isset($siblings[$index - 1]) ? $siblings[$index - 1]->id : false;
 
-			$siblings = $this->_loader
-				->getSiblings($page);
-			// We minus one here as we have to add one in the controller so 0 is
-			// the move to top option.
-			$nearestSibling = isset($siblings[$index - 1]) ? $siblings[$index - 1]->id : false;
-
-			$addAfter = false;
-			if ($index === 0) {
-				// Load the siblings and get the one which is at the top
-				$siblings = $this->_loader->getSiblings($page);
-				$nearestSibling = array_shift($siblings);
-				$addAfter = true;
-			} else {
-				// Otherwise just load the given sibling to move the page after
-				$nearestSibling = $this->_loader->getByID($nearestSibling);
-			}
-
-			$this->_nestedSetHelper->move(
-				$page->id,
-				$nearestSibling->id,
-				false,
-				$addAfter
-			);
-			$this->_transaction->commit();
-
-			return true;
-		} catch (Exception $e) {
-			return false;
+		$addAfter = false;
+		if ($index === 0) {
+			// Load the siblings and get the one which is at the top
+			$siblings = $this->_loader->getSiblings($page);
+			$nearestSibling = array_shift($siblings);
+			$addAfter = true;
+		} else {
+			// Otherwise just load the given sibling to move the page after
+			$nearestSibling = $this->_loader->getByID($nearestSibling);
 		}
+
+		if (!$nearestSibling) {
+			throw new Exception\PageEditException('Could not load nearest sibling');
+		}
+
+		$this->_nestedSetHelper->move(
+			$page->id,
+			$nearestSibling->id,
+			false,
+			$addAfter
+		);
+
+		return (bool) $this->_transaction->commit();
 	}
 
 	/**
@@ -315,17 +315,14 @@ class Edit implements TransactionalInterface
 	 *
 	 * @param int 	$pageID 		The ID of the page we are going to move
 	 * @param int   $newParentID 	The ID of the new parent we are moving to
+	 *
+	 * @return bool
 	 */
 	public function changeParent($pageID, $newParentID)
 	{
-		try {
-			$this->_nestedSetHelper->move($pageID, $newParentID, true);
-			$this->_transaction->commit();
+		$this->_nestedSetHelper->move($pageID, $newParentID, true);
 
-			return true;
-		} catch (\Exception $e) {
-			return false;
-		}
+		return (bool) $this->_transaction->commit();
 	}
 
 	/**

--- a/src/Page/Exception/PageEditException.php
+++ b/src/Page/Exception/PageEditException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Message\Mothership\CMS\Page\Exception;
+
+/**
+ * Class PageEditException
+ *
+ * @author Thomas Marchant <thomas@mothership.ec?
+ */
+class PageEditException extends \LogicException
+{
+
+}

--- a/translations/en.yml
+++ b/translations/en.yml
@@ -9,6 +9,14 @@ ms.cms:
         failure: Sorry, an error occurred while updating the content
       attributes:
         success: Attributes updated successfully
+        failure: Attributes could not be update
+        parent:
+          success: Parent successfully changed
+          failure: Parent could not be changed
+        order:
+          failure: Could not change the page order
+        nested-set:
+          error: The page could not be moved to a new position. This may be due to malformed data, please contact your web developer quoting the error: `%error%`.
       metadata:
         success: Metadata updated successfully
       title:


### PR DESCRIPTION
#### What does this do?

This pull request has been created as a result of the damage done to data by saving a sibling and parent to a page that are no valid with each other. This adds tighter validation and error reporting, and prevents users from being able to do this.

Requires https://github.com/mothership-ec/cog/pull/431

+ Catches `NestedSetExceptions` informing the user that their data is malformed and they will need to seek assistance from their web developer
+ Adds PageEditException
+ `changeParent()` and `changeOrder()` methods on `Page\Edit` return false if `Transaction::commit()` 
+ `changeOrder()` throws `PageEditException` if no page sibling can be found
+ `PageEditException` caught by attribute edit action
+ JavaScript to disable `Siblings` field on attributes edit screen if the parent has changed

#### How should this be manually tested?

#### Related PRs / Issues / Resources?

#### Anything else to add? (Screenshots, background context, etc)