### PR TITLE
Fix page ordering

### DIFF
--- a/src/Bootstrap/Tasks.php
+++ b/src/Bootstrap/Tasks.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Message\Mothership\CMS\Bootstrap;
+
+use Message\Cog\Bootstrap\TasksInterface;
+use Message\Mothership\CMS\Task;
+
+class Tasks implements TasksInterface
+{
+	public function registerTasks($tasks)
+	{
+		$tasks->add(new Task\FixPageTree('cms:page:fix_tree'), 'Fixes the page nested set tree (siblings and parents)');
+	}
+}

--- a/src/Controller/ControlPanel/Edit.php
+++ b/src/Controller/ControlPanel/Edit.php
@@ -216,8 +216,9 @@ class Edit extends \Message\Cog\Controller\Controller
 					$this->addFlash('error', 'The page could not be moved to a new position');
 				}
 			}
-
-			$page = $this->_updateSlug($page, $data['slug']);
+			if (!$page->isHomepage()) {
+				$page = $this->_updateSlug($page, $data['slug']);
+			}
 
 			$page->visibilitySearch     = $data['visibility_search'];
 			$page->visibilityMenu       = $data['visibility_menu'];

--- a/src/Page/Loader.php
+++ b/src/Page/Loader.php
@@ -675,9 +675,10 @@ class Loader
 			// Get the page type
 			$pages[$key]->type = $this->_pageTypes->get($data->type);
 
+
 			// If the page is the most left page then it is the homepage so
 			// we need to override the slug to avoid unnecessary redirects
-			if (1 == $data->left) {
+			if ($this->_getMinPositionLeft() == $data->left) {
 				$data->slug = new Slug('/');
 			}
 
@@ -749,6 +750,13 @@ class Loader
 		}
 
 		return count($pages) == 1 && !$this->_returnAsArray ? $pages[0] : $pages;
+	}
+
+	private function _getMinPositionLeft()
+	{
+		return $this->_query->run('
+				SELECT MIN(`position_left`) FROM `page` WHERE deleted_at IS NULL
+			')->value();
 	}
 
 	private function _getOrderQuery()

--- a/src/Task/FixPageTree.php
+++ b/src/Task/FixPageTree.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Message\Mothership\CMS\Task;
+
+use Message\Cog\Console\Task\Task;
+
+class FixPageTree extends Task
+{
+	private $_pageLoader;
+	private $_query;
+	private $_nestedSetHelper;
+
+	public function process()
+	{
+		$this->_query = $this->get('db.query');
+		$this->_nestedSetHelper = $this->get('cms.page.nested_set_helper');
+
+		$this->_pageLoader = $this->get('cms.page.loader');
+		$this->_pageLoader->includeDeleted(true);
+		$this->_pageLoader->includeUnpublished(true);
+
+		$tree = $this->_buildTree();
+		$this->_query->run($this->_clearTreeDataQuery());
+		$this->_buildNestedSet($tree);
+	}
+
+	private function _buildNestedSet($node)
+	{
+		foreach ($node->children as $child) {
+			$this->_nestedSetHelper->insertChildAtEnd($child->page, $node->page, true)->commit();
+			$this->_buildNestedSet($child);
+		}
+	}
+
+	private function _clearTreeDataQuery()
+	{
+		return "UPDATE `page` SET `position_left` = NULL, `position_right` = NULL, `position_depth` = NULL;";
+	}
+
+	private function _buildTree()
+	{
+		$root = new \stdClass;
+		$root->page = null;
+		$root->children = $this->_buildChildren($this->_pageLoader->getTopLevel());
+
+		return $root;
+	}
+
+	private function _buildChildren($nodes)
+	{
+		return array_map(function($x) {
+			$node = new \stdClass;
+			$node->page = $x->id;
+			$node->children = $this->_buildChildren($this->_pageLoader->getChildren($x));
+			return $node;
+		}, $nodes);
+	}
+}

--- a/src/Task/FixPageTree.php
+++ b/src/Task/FixPageTree.php
@@ -19,14 +19,31 @@ class FixPageTree extends Task
 		$this->_pageLoader->includeDeleted(true);
 		$this->_pageLoader->includeUnpublished(true);
 
+		$this->writeln('<info>Building page tree</info>');
 		$tree = $this->_buildTree();
+		$this->writeln('<info>Clearing tree data</info>');
 		$this->_query->run($this->_clearTreeDataQuery());
+		$this->writeln('<info>Refreshing nested set data</info>');
 		$this->_buildNestedSet($tree);
+		$this->writeln('<info>Refreshing orphaned pages</info>');
+		$this->_resetOrphanedPages();
+	}
+
+	private function _resetOrphanedPages()
+	{
+		$orphanedPages = $this->_query->run('SELECT `page_id` FROM `page` WHERE `position_left` IS NULL;')->flatten();
+		$this->writeln(count($orphanedPages) . ' orphaned pages found');
+
+		foreach ($orphanedPages as $page) {
+			$this->writeln('Reseting page ' . $page);
+			$this->_nestedSetHelper->insertChildAtEnd($page, null, true)->commit();
+		}
 	}
 
 	private function _buildNestedSet($node)
 	{
 		foreach ($node->children as $child) {
+			$this->writeln('Inserting page ' . $child->page . ' into parent ' . ($node->page ?: 'root'));
 			$this->_nestedSetHelper->insertChildAtEnd($child->page, $node->page, true)->commit();
 			$this->_buildNestedSet($child);
 		}


### PR DESCRIPTION
#### What does this do?
Adds a task to fix the nested set tree structure if something bad happens to the data. It also changes the loader to check for the unpublished page with the lowest position_left to use as the homepage instead of `left == 1`.

#### How should this be manually tested?

#### Related PRs / Issues / Resources?

#### Anything else to add? (Screenshots, background context, etc)

