### PR TITLE
Pinterest spelt wrongly

### DIFF
--- a/resources/fixtures/config/social.yml
+++ b/resources/fixtures/config/social.yml
@@ -7,6 +7,6 @@ facebook:
 instagram:
   name: # username
   slug: # slug to link to
-pintrest:
+pinterest:
   name: # username
   slug: # slug to link to

--- a/resources/view/modules/social/links.html.twig
+++ b/resources/view/modules/social/links.html.twig
@@ -14,9 +14,9 @@
 		<a href="https://www.facebook.com/{{ social.facebook.slug|default(social.facebook.name)|e('url') }}">Facebook</a>
 	</li>
 	{% endif %}
-	{% if not social.pintrest.name is empty %}
+	{% if not social.pinterest.name is empty %}
 	<li class="pinterest">
-		<a href="http://www.pinterest.com/{{ social.pintrest.slug|default(social.pintrest.name)|e('url') }}">Pinterest</a>
+		<a href="http://www.pinterest.com/{{ social.pinterest.slug|default(social.pinterest.name)|e('url') }}">Pinterest</a>
 	</li>
 	{% endif %}
 </ul>


### PR DESCRIPTION
I spelt pinterest wrong in a couple of places. Fixes for that.