### PR TITLE
Mothership defaults to social config

### DIFF
--- a/resources/fixtures/config/social.yml
+++ b/resources/fixtures/config/social.yml
@@ -7,6 +7,6 @@ facebook:
 instagram:
   name: # instagram
   slug: # slug to link to
-pintrest:
+pinterest:
   name: # pinterest
   slug: # slug to link to

--- a/resources/fixtures/config/social.yml
+++ b/resources/fixtures/config/social.yml
@@ -1,12 +1,12 @@
 twitter:
-  name: # username
+  name: Mothership_Ecom
   slug: # slug to link to
 facebook:
-  name: # username
+  name: mothership.ecommerce
   slug: # slug to link to
 instagram:
-  name: # username
+  name: # instagram
   slug: # slug to link to
-pinterest:
-  name: # username
+pintrest:
+  name: # pinterest
   slug: # slug to link to


### PR DESCRIPTION
We don't really want these to be in skel's cofig dir because it makes setup confusing as hell.