### PR TITLE
Add image translation for blog

### DIFF
--- a/translations/en.yml
+++ b/translations/en.yml
@@ -154,6 +154,7 @@ ms.cms:
     blog:
       body: Post body
       images: Images
+      image: Image
       caption_heading: Caption heading
       caption: Caption
       date: Display date


### PR DESCRIPTION
### What?
Adds image translation to the cms translations file.

### How to test
Remove this translation from a site; the blog image translation (when expanded) will be broken; switch to this branch; it will be fixed.