### PR TITLE
Set correct count query on page loader

### DIFF
--- a/src/Page/Loader.php
+++ b/src/Page/Loader.php
@@ -618,8 +618,8 @@ class Loader
 		);
 
 		if (null !== $this->_pagination) {
+			$this->_pagination->setCountQuery('SELECT COUNT(p.id) as `count` FROM (' . $sql . ') as p', $params);
 			$this->_pagination->setQuery($sql, $params);
-			$this->_pagination->setCountColumn('page.page_id');
 			$result = $this->_pagination->getCurrentPageResults();
 			$this->_pagination = null;
 		}


### PR DESCRIPTION
### What does it do?

Uses the correct query to count. The paginator was only allowing 1 page as `getCount()` was only returning 1.

### How to test

Use the page loader in conjunction with the `pagination` service - use `setPagination()` on the loader. Make lots of duplicate pages so it goes over 1 page. Try calling `getCount()`. Ensure the numbers are correct.