### PR TITLE
Page Filtering (and Page\Loader refactor)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 	"require": {
 		"php": ">=5.4.0",
 
-		"mothership-ec/cog"                         : "dev-feature/filtering-component as 4.4.0",
+		"mothership-ec/cog"                         : "~4.2",
 		"mothership-ec/cog-mothership-user"         : "~4.0",
 		"mothership-ec/cog-imageresize"             : "~2.0",
 		"mothership-ec/cog-mothership-cp"           : "~3.3",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 	"require": {
 		"php": ">=5.4.0",
 
-		"mothership-ec/cog"                         : "~4.2",
+		"mothership-ec/cog"                         : "dev-feature/filtering-component as 4.4.0",
 		"mothership-ec/cog-mothership-user"         : "~4.0",
 		"mothership-ec/cog-imageresize"             : "~2.0",
 		"mothership-ec/cog-mothership-cp"           : "~3.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "93f97c634be54da94f5759c261a59159",
+    "hash": "2930f74dfbdf5111d15b18d61d60bdea",
     "packages": [
         {
             "name": "dflydev/markdown",
@@ -626,16 +626,16 @@
         },
         {
             "name": "mothership-ec/cog",
-            "version": "4.2.0",
+            "version": "dev-feature/filtering-component",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mothership-ec/cog.git",
-                "reference": "36e21549f120a19996363cd595acbade3f1e5f3c"
+                "reference": "17d1a8f5af8b0660a594273200d45d96e0a744a7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mothership-ec/cog/zipball/36e21549f120a19996363cd595acbade3f1e5f3c",
-                "reference": "36e21549f120a19996363cd595acbade3f1e5f3c",
+                "url": "https://api.github.com/repos/mothership-ec/cog/zipball/17d1a8f5af8b0660a594273200d45d96e0a744a7",
+                "reference": "17d1a8f5af8b0660a594273200d45d96e0a744a7",
                 "shasum": ""
             },
             "require": {
@@ -700,6 +700,9 @@
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0+"
+            ],
             "authors": [
                 {
                     "name": "The Mothership Development Team",
@@ -712,7 +715,7 @@
                 "cog",
                 "framework"
             ],
-            "time": "2015-04-02 09:43:16"
+            "time": "2015-05-15 12:38:04"
         },
         {
             "name": "mothership-ec/cog-imageresize",
@@ -915,16 +918,16 @@
         },
         {
             "name": "mothership-ec/cog-mothership-user",
-            "version": "4.0.0",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mothership-ec/cog-mothership-user.git",
-                "reference": "c95dcdb1d9b49bceeb5f7688123729da038bf8ba"
+                "reference": "3a2c16bb6d502a004771196ab314a0777534c5db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mothership-ec/cog-mothership-user/zipball/c95dcdb1d9b49bceeb5f7688123729da038bf8ba",
-                "reference": "c95dcdb1d9b49bceeb5f7688123729da038bf8ba",
+                "url": "https://api.github.com/repos/mothership-ec/cog-mothership-user/zipball/3a2c16bb6d502a004771196ab314a0777534c5db",
+                "reference": "3a2c16bb6d502a004771196ab314a0777534c5db",
                 "shasum": ""
             },
             "require": {
@@ -961,7 +964,7 @@
                 "mothership",
                 "user"
             ],
-            "time": "2015-02-24 15:30:20"
+            "time": "2015-04-13 10:32:18"
         },
         {
             "name": "mothership-ec/cog-user",
@@ -1278,17 +1281,17 @@
         },
         {
             "name": "symfony/console",
-            "version": "v2.3.27",
+            "version": "v2.3.28",
             "target-dir": "Symfony/Component/Console",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Console.git",
-                "reference": "6081c3ca0284655996fa3d9f91063b8f0b669f3b"
+                "reference": "d446270de14e324e3b52ce82c83a7e33c480c808"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Console/zipball/6081c3ca0284655996fa3d9f91063b8f0b669f3b",
-                "reference": "6081c3ca0284655996fa3d9f91063b8f0b669f3b",
+                "url": "https://api.github.com/repos/symfony/Console/zipball/d446270de14e324e3b52ce82c83a7e33c480c808",
+                "reference": "d446270de14e324e3b52ce82c83a7e33c480c808",
                 "shasum": ""
             },
             "require": {
@@ -1318,31 +1321,31 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony Console Component",
-            "homepage": "http://symfony.com",
-            "time": "2015-03-27 22:05:05"
+            "homepage": "https://symfony.com",
+            "time": "2015-05-01 14:06:45"
         },
         {
             "name": "symfony/debug",
-            "version": "v2.6.6",
+            "version": "v2.6.7",
             "target-dir": "Symfony/Component/Debug",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Debug.git",
-                "reference": "d49a46a20a8f0544aedac54466750ad787d3d3e3"
+                "reference": "ad4511a8fddce7ec163b513ba39a30ea4f32c9e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Debug/zipball/d49a46a20a8f0544aedac54466750ad787d3d3e3",
-                "reference": "d49a46a20a8f0544aedac54466750ad787d3d3e3",
+                "url": "https://api.github.com/repos/symfony/Debug/zipball/ad4511a8fddce7ec163b513ba39a30ea4f32c9e7",
+                "reference": "ad4511a8fddce7ec163b513ba39a30ea4f32c9e7",
                 "shasum": ""
             },
             "require": {
@@ -1379,17 +1382,17 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony Debug Component",
-            "homepage": "http://symfony.com",
-            "time": "2015-03-22 16:55:57"
+            "homepage": "https://symfony.com",
+            "time": "2015-05-08 13:17:44"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -1444,17 +1447,17 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v2.3.27",
+            "version": "v2.3.28",
             "target-dir": "Symfony/Component/Filesystem",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Filesystem.git",
-                "reference": "012ef7ea60b4a980725fbe3c425d23b1d308f105"
+                "reference": "471ef4c1746a640482b81f489e7fca0334375921"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/012ef7ea60b4a980725fbe3c425d23b1d308f105",
-                "reference": "012ef7ea60b4a980725fbe3c425d23b1d308f105",
+                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/471ef4c1746a640482b81f489e7fca0334375921",
+                "reference": "471ef4c1746a640482b81f489e7fca0334375921",
                 "shasum": ""
             },
             "require": {
@@ -1480,17 +1483,17 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony Filesystem Component",
-            "homepage": "http://symfony.com",
-            "time": "2015-03-21 17:48:06"
+            "homepage": "https://symfony.com",
+            "time": "2015-05-06 16:34:36"
         },
         {
             "name": "symfony/finder",
@@ -1543,17 +1546,17 @@
         },
         {
             "name": "symfony/form",
-            "version": "v2.3.27",
+            "version": "v2.3.28",
             "target-dir": "Symfony/Component/Form",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Form.git",
-                "reference": "8c7fd0d584aa47e8ceb5c224db40aa28ed56636b"
+                "reference": "344ba760b39654518ceb0fc50d265eca4be66803"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Form/zipball/8c7fd0d584aa47e8ceb5c224db40aa28ed56636b",
-                "reference": "8c7fd0d584aa47e8ceb5c224db40aa28ed56636b",
+                "url": "https://api.github.com/repos/symfony/Form/zipball/344ba760b39654518ceb0fc50d265eca4be66803",
+                "reference": "344ba760b39654518ceb0fc50d265eca4be66803",
                 "shasum": ""
             },
             "require": {
@@ -1591,31 +1594,31 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony Form Component",
-            "homepage": "http://symfony.com",
-            "time": "2015-03-30 15:33:35"
+            "homepage": "https://symfony.com",
+            "time": "2015-05-01 14:06:45"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v2.6.6",
+            "version": "v2.6.7",
             "target-dir": "Symfony/Component/HttpFoundation",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/HttpFoundation.git",
-                "reference": "8a6337233f08f7520de97f4ffd6f00e947d892f9"
+                "reference": "8a0d00980ef9f6b47ddbf24bdfbf70fead760816"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/HttpFoundation/zipball/8a6337233f08f7520de97f4ffd6f00e947d892f9",
-                "reference": "8a6337233f08f7520de97f4ffd6f00e947d892f9",
+                "url": "https://api.github.com/repos/symfony/HttpFoundation/zipball/8a0d00980ef9f6b47ddbf24bdfbf70fead760816",
+                "reference": "8a0d00980ef9f6b47ddbf24bdfbf70fead760816",
                 "shasum": ""
             },
             "require": {
@@ -1645,31 +1648,31 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony HttpFoundation Component",
-            "homepage": "http://symfony.com",
-            "time": "2015-04-01 16:50:12"
+            "homepage": "https://symfony.com",
+            "time": "2015-05-02 15:18:45"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v2.3.27",
+            "version": "v2.3.28",
             "target-dir": "Symfony/Component/HttpKernel",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/HttpKernel.git",
-                "reference": "d33f5c343c2a73b5cf17e14630c97f4a47ce2d66"
+                "reference": "3cee6abfb450af315ac77b3163c03d6bf1237c81"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/HttpKernel/zipball/d33f5c343c2a73b5cf17e14630c97f4a47ce2d66",
-                "reference": "d33f5c343c2a73b5cf17e14630c97f4a47ce2d66",
+                "url": "https://api.github.com/repos/symfony/HttpKernel/zipball/3cee6abfb450af315ac77b3163c03d6bf1237c81",
+                "reference": "3cee6abfb450af315ac77b3163c03d6bf1237c81",
                 "shasum": ""
             },
             "require": {
@@ -1719,31 +1722,31 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony HttpKernel Component",
-            "homepage": "http://symfony.com",
-            "time": "2015-04-01 14:28:26"
+            "homepage": "https://symfony.com",
+            "time": "2015-05-10 15:02:48"
         },
         {
             "name": "symfony/intl",
-            "version": "v2.6.6",
+            "version": "v2.6.7",
             "target-dir": "Symfony/Component/Intl",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Intl.git",
-                "reference": "f6bc51bcce44aadcfa5c3eaaf2e0402ed33b63b1"
+                "reference": "12d374531e2bbd43bbe503cdc79f8d00c2f7422a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Intl/zipball/f6bc51bcce44aadcfa5c3eaaf2e0402ed33b63b1",
-                "reference": "f6bc51bcce44aadcfa5c3eaaf2e0402ed33b63b1",
+                "url": "https://api.github.com/repos/symfony/Intl/zipball/12d374531e2bbd43bbe503cdc79f8d00c2f7422a",
+                "reference": "12d374531e2bbd43bbe503cdc79f8d00c2f7422a",
                 "shasum": ""
             },
             "require": {
@@ -1779,10 +1782,6 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Bernhard Schussek",
                     "email": "bschussek@gmail.com"
                 },
@@ -1793,10 +1792,14 @@
                 {
                     "name": "Igor Wiedler",
                     "email": "igor@wiedler.ch"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "A PHP replacement layer for the C intl extension that includes additional data from the ICU library.",
-            "homepage": "http://symfony.com",
+            "homepage": "https://symfony.com",
             "keywords": [
                 "i18n",
                 "icu",
@@ -1805,21 +1808,21 @@
                 "l10n",
                 "localization"
             ],
-            "time": "2015-03-30 15:54:10"
+            "time": "2015-05-02 15:18:45"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v2.6.6",
+            "version": "v2.6.7",
             "target-dir": "Symfony/Component/OptionsResolver",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/OptionsResolver.git",
-                "reference": "d619503992eea05eb407a6db76e28dc1b7619416"
+                "reference": "ac469b57f9bb4fef66ecf48113476d13ce0bdea4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/OptionsResolver/zipball/d619503992eea05eb407a6db76e28dc1b7619416",
-                "reference": "d619503992eea05eb407a6db76e28dc1b7619416",
+                "url": "https://api.github.com/repos/symfony/OptionsResolver/zipball/ac469b57f9bb4fef66ecf48113476d13ce0bdea4",
+                "reference": "ac469b57f9bb4fef66ecf48113476d13ce0bdea4",
                 "shasum": ""
             },
             "require": {
@@ -1845,22 +1848,22 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony OptionsResolver Component",
-            "homepage": "http://symfony.com",
+            "homepage": "https://symfony.com",
             "keywords": [
                 "config",
                 "configuration",
                 "options"
             ],
-            "time": "2015-03-13 17:37:22"
+            "time": "2015-05-02 15:18:45"
         },
         {
             "name": "symfony/process",
@@ -1908,17 +1911,17 @@
         },
         {
             "name": "symfony/property-access",
-            "version": "v2.6.6",
+            "version": "v2.6.7",
             "target-dir": "Symfony/Component/PropertyAccess",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/PropertyAccess.git",
-                "reference": "b342f127c3ab73dd4069c2104cb76f1a1ef7c7e7"
+                "reference": "1a913a7c2f2441e37485c79e658a261350546351"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/PropertyAccess/zipball/b342f127c3ab73dd4069c2104cb76f1a1ef7c7e7",
-                "reference": "b342f127c3ab73dd4069c2104cb76f1a1ef7c7e7",
+                "url": "https://api.github.com/repos/symfony/PropertyAccess/zipball/1a913a7c2f2441e37485c79e658a261350546351",
+                "reference": "1a913a7c2f2441e37485c79e658a261350546351",
                 "shasum": ""
             },
             "require": {
@@ -1944,16 +1947,16 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony PropertyAccess Component",
-            "homepage": "http://symfony.com",
+            "homepage": "https://symfony.com",
             "keywords": [
                 "access",
                 "array",
@@ -1965,21 +1968,21 @@
                 "property path",
                 "reflection"
             ],
-            "time": "2015-03-30 15:54:10"
+            "time": "2015-05-02 15:18:45"
         },
         {
             "name": "symfony/routing",
-            "version": "v2.3.27",
+            "version": "v2.3.28",
             "target-dir": "Symfony/Component/Routing",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Routing.git",
-                "reference": "a6f4dc55fe3d2ba3a0efa145c3efb373992e92e7"
+                "reference": "d4181ab9f26e3bb7430f49aa2956e8ea6568630f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Routing/zipball/a6f4dc55fe3d2ba3a0efa145c3efb373992e92e7",
-                "reference": "a6f4dc55fe3d2ba3a0efa145c3efb373992e92e7",
+                "url": "https://api.github.com/repos/symfony/Routing/zipball/d4181ab9f26e3bb7430f49aa2956e8ea6568630f",
+                "reference": "d4181ab9f26e3bb7430f49aa2956e8ea6568630f",
                 "shasum": ""
             },
             "require": {
@@ -2015,17 +2018,17 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony Routing Component",
-            "homepage": "http://symfony.com",
-            "time": "2015-03-27 22:05:05"
+            "homepage": "https://symfony.com",
+            "time": "2015-05-01 14:06:45"
         },
         {
             "name": "symfony/templating",
@@ -2073,17 +2076,17 @@
         },
         {
             "name": "symfony/translation",
-            "version": "v2.3.27",
+            "version": "v2.3.28",
             "target-dir": "Symfony/Component/Translation",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Translation.git",
-                "reference": "600ef7febf07aec56f3d2579fd1496cd332d9112"
+                "reference": "ab156d547f6b8774ea8760174928a1c775aec4c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Translation/zipball/600ef7febf07aec56f3d2579fd1496cd332d9112",
-                "reference": "600ef7febf07aec56f3d2579fd1496cd332d9112",
+                "url": "https://api.github.com/repos/symfony/Translation/zipball/ab156d547f6b8774ea8760174928a1c775aec4c7",
+                "reference": "ab156d547f6b8774ea8760174928a1c775aec4c7",
                 "shasum": ""
             },
             "require": {
@@ -2116,31 +2119,31 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony Translation Component",
-            "homepage": "http://symfony.com",
-            "time": "2015-03-30 15:33:35"
+            "homepage": "https://symfony.com",
+            "time": "2015-05-01 14:06:45"
         },
         {
             "name": "symfony/twig-bridge",
-            "version": "v2.3.27",
+            "version": "v2.3.28",
             "target-dir": "Symfony/Bridge/Twig",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/TwigBridge.git",
-                "reference": "5cfba56d1765c5a60477c84ba55a7f9454ff746b"
+                "reference": "ed28bdd66dbbf7134a95fe3fbb2a6a1df6fbf00e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/TwigBridge/zipball/5cfba56d1765c5a60477c84ba55a7f9454ff746b",
-                "reference": "5cfba56d1765c5a60477c84ba55a7f9454ff746b",
+                "url": "https://api.github.com/repos/symfony/TwigBridge/zipball/ed28bdd66dbbf7134a95fe3fbb2a6a1df6fbf00e",
+                "reference": "ed28bdd66dbbf7134a95fe3fbb2a6a1df6fbf00e",
                 "shasum": ""
             },
             "require": {
@@ -2186,31 +2189,31 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony Twig Bridge",
-            "homepage": "http://symfony.com",
-            "time": "2015-03-26 13:42:51"
+            "homepage": "https://symfony.com",
+            "time": "2015-05-01 14:06:45"
         },
         {
             "name": "symfony/twig-bundle",
-            "version": "v2.3.27",
+            "version": "v2.3.28",
             "target-dir": "Symfony/Bundle/TwigBundle",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/TwigBundle.git",
-                "reference": "ff0c9c7bedfdc25be29afe83ac66edd6733dca7a"
+                "reference": "b84b3793c0cb524454a33be2d719c34535a4afb5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/TwigBundle/zipball/ff0c9c7bedfdc25be29afe83ac66edd6733dca7a",
-                "reference": "ff0c9c7bedfdc25be29afe83ac66edd6733dca7a",
+                "url": "https://api.github.com/repos/symfony/TwigBundle/zipball/b84b3793c0cb524454a33be2d719c34535a4afb5",
+                "reference": "b84b3793c0cb524454a33be2d719c34535a4afb5",
                 "shasum": ""
             },
             "require": {
@@ -2242,31 +2245,31 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony TwigBundle",
-            "homepage": "http://symfony.com",
-            "time": "2015-03-21 11:11:30"
+            "homepage": "https://symfony.com",
+            "time": "2015-05-01 14:06:45"
         },
         {
             "name": "symfony/validator",
-            "version": "v2.3.27",
+            "version": "v2.3.28",
             "target-dir": "Symfony/Component/Validator",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Validator.git",
-                "reference": "f267428a04bc567d6a14c71208be2d05b4cc2ee5"
+                "reference": "105e8c3b2925136a725d3cc1c37f66ced7e3b0e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Validator/zipball/f267428a04bc567d6a14c71208be2d05b4cc2ee5",
-                "reference": "f267428a04bc567d6a14c71208be2d05b4cc2ee5",
+                "url": "https://api.github.com/repos/symfony/Validator/zipball/105e8c3b2925136a725d3cc1c37f66ced7e3b0e4",
+                "reference": "105e8c3b2925136a725d3cc1c37f66ced7e3b0e4",
                 "shasum": ""
             },
             "require": {
@@ -2305,17 +2308,17 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony Validator Component",
-            "homepage": "http://symfony.com",
-            "time": "2015-03-30 15:33:35"
+            "homepage": "https://symfony.com",
+            "time": "2015-05-01 14:06:45"
         },
         {
             "name": "symfony/yaml",
@@ -2507,9 +2510,18 @@
         }
     ],
     "packages-dev": [],
-    "aliases": [],
+    "aliases": [
+        {
+            "alias": "4.4.0",
+            "alias_normalized": "4.4.0.0",
+            "version": "dev-feature/filtering-component",
+            "package": "mothership-ec/cog"
+        }
+    ],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "mothership-ec/cog": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/readme.md
+++ b/readme.md
@@ -57,4 +57,3 @@ asset.use
 
 
 **note: we could add a config option for the service name for the page type collection and user groups collection (so the app can swap them out if they like)**
-

--- a/resources/assets/js/filter-pages.js
+++ b/resources/assets/js/filter-pages.js
@@ -48,6 +48,7 @@ function filterPages(ajaxUrl, filterDestinationID, method, formID, paginationMen
 	 * Collection form data and add it to the end of a URL
 	 *
 	 * @param url {string}
+	 * @param removeExisting {boolean}
 	 * @returns {string}
 	 */
 	function appendFormDataToUrl(url, removeExisting) {

--- a/resources/assets/js/filter-pages.js
+++ b/resources/assets/js/filter-pages.js
@@ -29,7 +29,7 @@ function filterPages(ajaxUrl, filterDestinationID, method, formID, paginationMen
 		if (submitMethod.toLowerCase() === 'get') {
 			$(paginationMenuLinks).attr('href', function (i) {
 				var url = $(this).attr('href');
-				return appendFormDataToUrl(url);
+				return appendFormDataToUrl(url, false);
 			});
 		}
 	}
@@ -40,7 +40,7 @@ function filterPages(ajaxUrl, filterDestinationID, method, formID, paginationMen
 	function appendFormDataToAddressUrl() {
 		if (submitMethod.toLowerCase() === 'get') {
 			var url = window.location.href;
-			window.history.pushState('string', 'Title', appendFormDataToUrl(url));
+			window.history.pushState('string', 'Title', appendFormDataToUrl(url, true));
 		}
 	}
 
@@ -50,9 +50,16 @@ function filterPages(ajaxUrl, filterDestinationID, method, formID, paginationMen
 	 * @param url {string}
 	 * @returns {string}
 	 */
-	function appendFormDataToUrl(url) {
-		var baseUrl = url.split('?')[0]
+	function appendFormDataToUrl(url, removeExisting) {
+		var baseUrl = url.split('?')[0],
+			dataString = form.serialize()
 			;
+
+		if (removeExisting && dataString) {
+			return baseUrl + '?' + dataString;
+		} else if (removeExisting) {
+			return baseUrl;
+		}
 
 		return baseUrl + '?' + replaceParams(url);
 	}

--- a/resources/assets/js/filter-pages.js
+++ b/resources/assets/js/filter-pages.js
@@ -1,0 +1,113 @@
+/**
+ * Activate AJAX request when filter form values are changed
+ *
+ * @param ajaxUrl               URL to send AJAX request to
+ * @param filterDestinationID   Identifier to inject response HTML into
+ * @param method                Method to submit the form with
+ * @param formID                The filtering form ID, defaults to '#page-filter-form'
+ * @param paginationMenuID      The ID of the pagination menu, defaults to '#pagination-menu'
+ */
+function filterPages(ajaxUrl, filterDestinationID, method, formID, paginationMenuID) {
+
+	var	filterDestination = $(filterDestinationID),
+		form = $(formID || '#page-filter-form'),
+		submitMethod = method || 'get',
+		button = form.find(':submit'),
+		paginationMenuLinks = paginationMenuID ? paginationMenuID + ' a' : '#pagination-menu a'
+		;
+
+	if (submitMethod.toLowerCase() !== 'get' && submitMethod.toLowerCase !== 'post') {
+		alert('Third parameter must be either \'post\' or \'get\'');
+	}
+
+	function appendFormDataToPagination() {
+		if (submitMethod.toLowerCase() === 'get') {
+			$(paginationMenuLinks).attr('href', function (i) {
+				var url = $(this).attr('href');
+				return appendFormDataToUrl(url);
+			});
+		}
+	}
+
+	function appendFormDataToAddressUrl() {
+		var url = window.location.href;
+		window.history.pushState('string', 'Title', appendFormDataToUrl(url));
+	}
+	
+	function appendFormDataToUrl(url) {
+		var	dataString = form.serialize(),
+			baseUrl = url.split('?')[0]
+			;
+
+		if (dataString) {
+			return baseUrl + '?' + replaceParams(url);
+		}
+
+		return url;
+	}
+
+	function replaceParams(url) {
+		var paramString = url.substring(url.indexOf('?') + 1),
+			paramArray = paramString.split('&'),
+			dataArray = form.serializeArray(),
+			params = {},
+			newParamString = '',
+			first = true
+		;
+
+		$.each(paramArray, function(i, v) {
+			var split = v.split('=');
+
+			if (split.length === 2) {
+				params[decodeURIComponent(split[0])] = split[1];
+			}
+		});
+
+		$.each(dataArray, function(i, v) {
+			var pattern = /\[\]$/;
+
+			if (pattern.test(v['name'])) {
+				if (typeof params[v['name']] === 'undefined' || params[v['name']].constructor !== Array) {
+					params[v['name']] = [];
+				}
+				params[v['name']].push(v['value']);
+			} else {
+				params[v['name']] = v['value'];
+			}
+		});
+
+		console.log($.param(params));
+
+		$.each(params, function(i, v) {
+			if (false === first) {
+				newParamString += '&';
+			}
+			newParamString += encodeURIComponent(i) + '=' + encodeURIComponent(v);
+			first = false;
+		});
+
+		return newParamString;
+	}
+
+	button.hide();
+
+	appendFormDataToPagination();
+
+	form.change(function () {
+		filterDestination.addClass('loading');
+		$.ajax({
+			url: ajaxUrl,
+			type: submitMethod,
+			data: form.serialize(),
+			success: function (data) {
+				filterDestination.html(data);
+				appendFormDataToPagination();
+				appendFormDataToAddressUrl();
+			}
+		});
+		filterDestination.removeClass('loading');
+
+		appendFormDataToPagination();
+		appendFormDataToAddressUrl();
+	});
+}

--- a/resources/view/modules/filter_form.html.twig
+++ b/resources/view/modules/filter_form.html.twig
@@ -1,4 +1,4 @@
-{{ form_start(form) }}
+{{ form_start(form, {attr: {id: 'page-filter-form'}}) }}
 {{ form_rest(form) }}
 <button type="submit" class="filter-form-button">{{ 'ms.cms.blog_comment.form.button.submit'|trans }}</button>
 {{ form_end(form) }}

--- a/resources/view/modules/filter_form.html.twig
+++ b/resources/view/modules/filter_form.html.twig
@@ -1,4 +1,4 @@
 {{ form_start(form, {attr: {id: 'page-filter-form'}}) }}
 {{ form_rest(form) }}
-<button type="submit" class="filter-form-button">{{ 'ms.cms.blog_comment.form.button.submit'|trans }}</button>
+<button type="submit" id="filter-form-button">{{ 'ms.cms.blog_comment.form.button.submit'|trans }}</button>
 {{ form_end(form) }}

--- a/resources/view/modules/filter_form.html.twig
+++ b/resources/view/modules/filter_form.html.twig
@@ -1,0 +1,4 @@
+{{ form_start(form) }}
+{{ form_rest(form) }}
+<button type="submit" class="filter-form-button">{{ 'ms.cms.blog_comment.form.button.submit'|trans }}</button>
+{{ form_end(form) }}

--- a/src/Bootstrap/Services.php
+++ b/src/Bootstrap/Services.php
@@ -92,9 +92,9 @@ class Services implements ServicesInterface
 			return new CMS\Page\Authorisation($c['user.group.loader'], $c['user.current']);
 		});
 
-		$services['cms.page.tag.loader'] = $services->factory(function($c) {
-			return new CMS\Page\TagLoader($c['db.query']);
-		});
+		$services['cms.page.tag.loader'] = function($c) {
+			return new CMS\Page\TagLoader($c['db.query.builder.factory']);
+		};
 
 		$services['cms.page.create'] = $services->factory(function($c) {
 			return new CMS\Page\Create(

--- a/src/Bootstrap/Services.php
+++ b/src/Bootstrap/Services.php
@@ -30,8 +30,7 @@ class Services implements ServicesInterface
 
 		$services['cms.page.loader'] = $services->factory(function($c) {
 			return new CMS\Page\Loader(
-				'Locale class',
-				$c['db.query'],
+				$c['db.query.builder.factory'],
 				$c['cms.page.types'],
 				$c['user.groups'],
 				$c['cms.page.authorisation'],

--- a/src/Controller/ControlPanel/Edit.php
+++ b/src/Controller/ControlPanel/Edit.php
@@ -424,6 +424,7 @@ class Edit extends \Message\Cog\Controller\Controller
 		))->val()->optional();
 
 		$siblings = $this->get('cms.page.loader')->getSiblings($page);
+
 		$siblingChoices = array();
 		if ($siblings) {
 			$siblingChoices[0] = 'Move to top';

--- a/src/Controller/Module/PageFilter.php
+++ b/src/Controller/Module/PageFilter.php
@@ -18,6 +18,8 @@ class PageFilter extends Controller
 	/**
 	 * @param string | FilterCollection $filters       The name of the service for the filter collection to use when
 	 *                                                 building the form
+	 *
+	 * @return \Message\Cog\HTTP\Response
 	 */
 	public function filterForm($filters)
 	{

--- a/src/Controller/Module/PageFilter.php
+++ b/src/Controller/Module/PageFilter.php
@@ -39,7 +39,27 @@ class PageFilter extends Controller
 		}
 
 		return $this->render('Message:Mothership:CMS::modules:filter_form', [
-			'form' => $this->createForm($this->get('filter.form_factory')->getForm($filters), $data, $options)
+			'form' => $this->_getForm($filters, $data, $options)
 		]);
+	}
+
+	/**
+	 * Gets the data to populate the form. Unfortunately this is somewhat inefficient as it involves building
+	 * the form twice, but I can't think of a better way to do it.
+	 *
+	 * @param FilterCollection $filters
+	 * @param array $data
+	 * @param array $options
+	 *
+	 * @return \Symfony\Component\Form\Form;
+	 */
+	private function _getForm(FilterCollection $filters, array $data = null, array $options = [])
+	{
+		$form = $this->createForm($this->get('filter.form_factory')->getForm($filters));
+		$form->handleRequest();
+
+		$data = $form->getData() ?: $data;
+
+		return $this->createForm($this->get('filter.form_factory')->getForm($filters), $data, $options);
 	}
 }

--- a/src/Controller/Module/PageFilter.php
+++ b/src/Controller/Module/PageFilter.php
@@ -18,10 +18,12 @@ class PageFilter extends Controller
 	/**
 	 * @param string | FilterCollection $filters       The name of the service for the filter collection to use when
 	 *                                                 building the form
+	 * @param array $data
+	 * @param array $options
 	 *
 	 * @return \Message\Cog\HTTP\Response
 	 */
-	public function filterForm($filters)
+	public function filterForm($filters, array $data = null, array $options = [])
 	{
 		if (!is_string($filters) && !$filters instanceof FilterCollection) {
 			throw new \InvalidArgumentException('Parameter to render filter form must be either the service name of the filter collection or an instance of \\Message\\Cog\\Filter\\FilterCollection');
@@ -37,7 +39,7 @@ class PageFilter extends Controller
 		}
 
 		return $this->render('Message:Mothership:CMS::modules:filter_form', [
-			'form' => $this->createForm($this->get('filter.form_factory')->getForm($filters))
+			'form' => $this->createForm($this->get('filter.form_factory')->getForm($filters), $data, $options)
 		]);
 	}
 }

--- a/src/Controller/Module/PageFilter.php
+++ b/src/Controller/Module/PageFilter.php
@@ -44,8 +44,7 @@ class PageFilter extends Controller
 	}
 
 	/**
-	 * Gets the data to populate the form. Unfortunately this is somewhat inefficient as it involves building
-	 * the form twice, but I can't think of a better way to do it.
+	 * Builds the form, assigning data and options
 	 *
 	 * @param FilterCollection $filters
 	 * @param array $data
@@ -55,11 +54,9 @@ class PageFilter extends Controller
 	 */
 	private function _getForm(FilterCollection $filters, array $data = null, array $options = [])
 	{
-		$form = $this->createForm($this->get('filter.form_factory')->getForm($filters));
+		$form = $this->createForm($this->get('filter.form_factory')->getForm($filters), $data, $options);
 		$form->handleRequest();
 
-		$data = $form->getData() ?: $data;
-
-		return $this->createForm($this->get('filter.form_factory')->getForm($filters), $data, $options);
+		return $form;
 	}
 }

--- a/src/Controller/Module/PageFilter.php
+++ b/src/Controller/Module/PageFilter.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Message\Mothership\CMS\Controller\Module;
+
+use Message\Cog\Controller\Controller;
+use Message\Cog\Filter\FilterCollection;
+
+/**
+ * Class PageFilter
+ * @package Message\Mothership\CMS\Controller\Module
+ *
+ * @author  Thomas Marchant <thomas@mothership.ec>
+ *
+ * Module for handling page filtering form
+ */
+class PageFilter extends Controller
+{
+	/**
+	 * @param string | FilterCollection $filters       The name of the service for the filter collection to use when
+	 *                                                 building the form
+	 */
+	public function filterForm($filters)
+	{
+		if (!is_string($filters) && !$filters instanceof FilterCollection) {
+			throw new \InvalidArgumentException('Parameter to render filter form must be either the service name of the filter collection or an instance of \\Message\\Cog\\Filter\\FilterCollection');
+		} elseif (is_string($filters)) {
+
+			$filterCollection = $this->get($filters);
+
+			if (!$filterCollection instanceof FilterCollection) {
+				throw new \LogicException('Service with name `' . $filters . '` must be an instance of \\Message\\Cog\\Filter\\FilterCollection');
+			}
+
+			$filters = $filterCollection;
+		}
+
+		return $this->render('Message:Mothership:CMS::modules:filter_form', [
+			'form' => $this->createForm($this->get('filter.form_factory')->getForm($filters))
+		]);
+	}
+}

--- a/src/Form/RangeFilterForm.php
+++ b/src/Form/RangeFilterForm.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Message\Mothership\CMS\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+class RangeFilterForm extends AbstractType
+{
+	const MIN = 'min';
+	const MAX = 'max';
+
+	const MIN_LABEL = 'ms.cms.page_filter.min';
+	const MAX_LABEL = 'ms.cms.page_filter.max';
+
+	public function getName()
+	{
+		return 'cms_page_range_filter';
+	}
+
+	public function buildForm(FormBuilderInterface $builder, array $options)
+	{
+		$builder->add(self::MIN, 'choice', [
+			'label'    => $options['min_label'],
+			'choices'  => $options['choices'],
+			'multiple' => false,
+			'expanded' => $options['expanded'],
+		]);
+
+		$builder->add(self::MAX, 'choice', [
+			'label'    => $options['max_label'],
+			'choices'  => $options['choices'],
+			'multiple' => false,
+			'expanded' => $options['expanded'],
+		]);
+	}
+
+	public function setDefaultOptions(OptionsResolverInterface $resolver)
+	{
+		$resolver->setDefaults([
+			'min_label' => self::MIN_LABEL,
+			'max_label' => self::MAX_LABEL,
+			'choices'   => [],
+			'expanded'  => false,
+		]);
+	}
+}

--- a/src/Page/Filter/AbstractContentFilter.php
+++ b/src/Page/Filter/AbstractContentFilter.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Message\Mothership\CMS\Page\Filter;
+
+use Message\Cog\Filter\AbstractFilter;
+
+/**
+ * Class AbstractContentFilter
+ * @package Message\Mothership\CMS\Page\Filter
+ *
+ * @author  Thomas Marchant <thomas@mothership.ec>
+ *
+ * Abstract classes for content filters, includes `setField()` method as well as method for generating a join
+ * statement to give to the query builder
+ */
+abstract class AbstractContentFilter extends AbstractFilter implements ContentFilterInterface
+{
+	/**
+	 * @var string
+	 */
+	protected $_field;
+
+	/**
+	 * @var string
+	 */
+	protected $_group;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function setField($field, $group = null)
+	{
+		if (!is_string($field)) {
+			throw new \InvalidArgumentException('Field must be a string, ' . gettype($field) . ' given');
+		}
+
+		if (null !== $group && !is_string($group)) {
+			throw new \InvalidArgumentException('Group must be a string, ' . gettype($group) . ' given');
+		} elseif ($group) {
+			$this->_group = $group;
+		}
+
+		$this->_field = $field;
+	}
+	
+	/**
+	 * Build a join statement for the query builder based on the group
+	 *
+	 * @return string
+	 */
+	protected function _getJoinStatement()
+	{
+		return 'page.page_id = ' . $this->_getContentAlias() . '.page_id  AND (' . $this->_getContentAlias() . '.group_name '
+		. ($this->_group ?
+			'= \'' . $this->_group . '\'' :
+			' IS NULL OR ' . $this->_getContentAlias() . '.group_name = \'\''
+		) . ')';
+	}
+
+	/**
+	 * Get the alias for the `page_content` table to include in the join statement
+	 *
+	 * @return string
+	 */
+	abstract protected function _getContentAlias();
+}

--- a/src/Page/Filter/AbstractContentFilter.php
+++ b/src/Page/Filter/AbstractContentFilter.php
@@ -11,7 +11,7 @@ use Message\Cog\Filter\AbstractFilter;
  * @author  Thomas Marchant <thomas@mothership.ec>
  *
  * Abstract classes for content filters, includes `setField()` method as well as method for generating a join
- * statement to give to the query builder
+ * statement to give to the query builder.
  */
 abstract class AbstractContentFilter extends AbstractFilter implements ContentFilterInterface
 {

--- a/src/Page/Filter/AbstractContentFilter.php
+++ b/src/Page/Filter/AbstractContentFilter.php
@@ -15,10 +15,7 @@ use Message\Cog\Filter\AbstractFilter;
  */
 abstract class AbstractContentFilter extends AbstractFilter implements ContentFilterInterface
 {
-	/**
-	 * @var string
-	 */
-	protected $_alias;
+	const DB_ALIAS = 'page_content_filter';
 
 	/**
 	 * @var string
@@ -67,14 +64,6 @@ abstract class AbstractContentFilter extends AbstractFilter implements ContentFi
 	 */
 	protected function _getContentAlias()
 	{
-		if (!is_string($this->_alias)) {
-			throw new \InvalidArgumentException('Alias must be a string, ' . gettype($this->_alias) . ' given');
-		}
-
-		if (null === $this->_field) {
-			throw new \LogicException('Cannot create table alias, field not set');
-		}
-
-		return $this->_alias . '_' . $this->_field . ($this->_group ? '_' . $this->_group : '');
+		return self::DB_ALIAS . '_' . $this->getName();
 	}
 }

--- a/src/Page/Filter/AbstractContentFilter.php
+++ b/src/Page/Filter/AbstractContentFilter.php
@@ -18,6 +18,11 @@ abstract class AbstractContentFilter extends AbstractFilter implements ContentFi
 	/**
 	 * @var string
 	 */
+	protected $_alias;
+
+	/**
+	 * @var string
+	 */
 	protected $_field;
 
 	/**
@@ -42,7 +47,7 @@ abstract class AbstractContentFilter extends AbstractFilter implements ContentFi
 
 		$this->_field = $field;
 	}
-	
+
 	/**
 	 * Build a join statement for the query builder based on the group
 	 *
@@ -58,9 +63,18 @@ abstract class AbstractContentFilter extends AbstractFilter implements ContentFi
 	}
 
 	/**
-	 * Get the alias for the `page_content` table to include in the join statement
-	 *
-	 * @return string
+	 * Get the alias for the joined content table from the database
 	 */
-	abstract protected function _getContentAlias();
+	protected function _getContentAlias()
+	{
+		if (!is_string($this->_alias)) {
+			throw new \InvalidArgumentException('Alias must be a string, ' . gettype($this->_alias) . ' given');
+		}
+
+		if (null === $this->_field) {
+			throw new \LogicException('Cannot create table alias, field not set');
+		}
+
+		return $this->_alias . '_' . $this->_field . ($this->_group ? '_' . $this->_group : '');
+	}
 }

--- a/src/Page/Filter/ContentFilter.php
+++ b/src/Page/Filter/ContentFilter.php
@@ -15,8 +15,6 @@ use Message\Cog\DB\QueryBuilderInterface;
  */
 class ContentFilter extends AbstractContentFilter
 {
-	protected $_alias = 'content_filter_pc';
-
 	/**
 	 * @var QueryBuilderFactory
 	 */

--- a/src/Page/Filter/ContentFilter.php
+++ b/src/Page/Filter/ContentFilter.php
@@ -15,7 +15,7 @@ use Message\Cog\DB\QueryBuilderInterface;
  */
 class ContentFilter extends AbstractContentFilter
 {
-	const CONTENT_ALIAS = 'content_filter_pc';
+	protected $_alias = 'content_filter_pc';
 
 	/**
 	 * @var QueryBuilderFactory
@@ -108,13 +108,5 @@ class ContentFilter extends AbstractContentFilter
 		}
 
 		$this->setOptions(['choices' => $choices]);
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	protected function _getContentAlias()
-	{
-		return self::CONTENT_ALIAS;
 	}
 }

--- a/src/Page/Filter/ContentFilter.php
+++ b/src/Page/Filter/ContentFilter.php
@@ -27,7 +27,7 @@ class ContentFilter extends AbstractContentFilter
 	 *
 	 * Include instance of QueryBuilderFactory to allow choices to be automatically loaded
 	 */
-	public function __construct($name, $displayName, QueryBuilderFactory $queryBuilderFactory)
+	public function __construct($name, $displayName, QueryBuilderFactory $queryBuilderFactory = null)
 	{
 		parent::__construct($name, $displayName);
 
@@ -36,13 +36,22 @@ class ContentFilter extends AbstractContentFilter
 
 	/**
 	 * {@inheritDoc}
-	 *
-	 * Call `setChoices()` after assigning the field and group
 	 */
 	public function setField($field, $group = null)
 	{
 		parent::setField($field, $group);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * Method calls `_setChoices()` to generate choices if they are not set
+	 */
+	public function getForm()
+	{
 		$this->_setChoices();
+
+		return parent::getForm();
 	}
 
 	/**
@@ -76,10 +85,15 @@ class ContentFilter extends AbstractContentFilter
 	}
 
 	/**
-	 * Load content assigned to field
+	 * Load choices for form field if not already set, and if there is an instance of QueryBuilderFactory set
+	 * against the filter class
 	 */
 	private function _setChoices()
 	{
+		if (null === $this->_queryBuilderFactory || !empty($this->getOptions()['choices'])) {
+			return;
+		}
+
 		$queryBuilder = $this->_queryBuilderFactory->getQueryBuilder()
 			->select('value_string', true)
 			->from('page_content')

--- a/src/Page/Filter/ContentFilter.php
+++ b/src/Page/Filter/ContentFilter.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Message\Mothership\CMS\Page\Filter;
+
+use Message\Cog\Filter\AbstractFilter;
+use Message\Cog\DB\QueryBuilderFactory;
+use Message\Cog\DB\QueryBuilderInterface;
+
+/**
+ * Class ContentFilter
+ *
+ * @author Thomas Marchant <thomas@mothership.ec>
+ */
+class ContentFilter extends AbstractFilter implements ContentFilterInterface
+{
+	/**
+	 * @var QueryBuilderFactory
+	 */
+	private $_queryBuilderFactory;
+
+	/**
+	 * @var string
+	 */
+	protected $_field;
+
+	/**
+	 * @var string
+	 */
+	protected $_group;
+
+	public function __construct($name, $displayName, QueryBuilderFactory $queryBuilderFactory)
+	{
+		parent::__construct($name, $displayName);
+
+		$this->_queryBuilderFactory = $queryBuilderFactory;
+	}
+
+	public function setField($field, $group = null)
+	{
+		if (!is_string($field)) {
+			throw new \InvalidArgumentException('Field must be a string, ' . gettype($field) . ' given');
+		}
+
+		if (null !== $group && !is_string($group)) {
+			throw new \InvalidArgumentException('Group must be a string, ' . gettype($group) . ' given');
+		} elseif ($group) {
+			$this->_group = $group;
+		}
+
+		$this->_setChoices();
+
+		$this->_field = $field;
+	}
+
+	public function setValue($value)
+	{
+		if ($value instanceof \DateTime) {
+			$this->_value = (string) $value->getTimestamp();
+		} else {
+			$this->_value = (string) $value;
+		}
+	}
+
+	protected function _applyFilter(QueryBuilderInterface $queryBuilder)
+	{
+		$queryBuilder->leftJoin('page_content', 'page.page_id = page_content.page_id')
+			->where('page_content.field_name = ?s', [$this->_field])
+			->where('page_content.value_string = ?s', [$this->_value])
+		;
+
+		if ($this->_group) {
+			$queryBuilder->where('page_content.group_name = ?s', [$this->_group]);
+		}
+	}
+
+	private function _setChoices()
+	{
+		$result = $this->_queryBuilderFactory->getQueryBuilder()
+			->select('value_string', true)
+			->from('page_content')
+			->where('field_name = ?s', [$this->_field])
+			->getQuery()
+			->run()
+			->flatten()
+		;
+
+		$choices = [];
+
+		foreach ($result as $value) {
+			$choices[$value] = $value;
+		}
+
+		$this->setOptions(['choices' => $choices]);
+	}
+}

--- a/src/Page/Filter/ContentFilterInterface.php
+++ b/src/Page/Filter/ContentFilterInterface.php
@@ -10,5 +10,11 @@ namespace Message\Mothership\CMS\Page\Filter;
  */
 interface ContentFilterInterface
 {
+	/**
+	 * Set the content field to filter by
+	 *
+	 * @param string $name              Name of the field to filter by
+	 * @param string | null $group      Name of group field belongs to, if necessary
+	 */
 	public function setField($name, $group = null);
 }

--- a/src/Page/Filter/ContentFilterInterface.php
+++ b/src/Page/Filter/ContentFilterInterface.php
@@ -7,6 +7,9 @@ namespace Message\Mothership\CMS\Page\Filter;
  * @package Message\Mothership\CMS\Page\Filter
  *
  * @author  Thomas Marchant <thomas@mothership.ec>
+ *
+ * Interface representing filters that filter by page content.
+ * Includes `setField()` method for setting the field to filter content by.
  */
 interface ContentFilterInterface
 {

--- a/src/Page/Filter/ContentFilterInterface.php
+++ b/src/Page/Filter/ContentFilterInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Message\Mothership\CMS\Page\Filter;
+
+/**
+ * Interface ContentFilterInterface
+ * @package Message\Mothership\CMS\Page\Filter
+ *
+ * @author  Thomas Marchant <thomas@mothership.ec>
+ */
+interface ContentFilterInterface
+{
+	public function setField($name, $group = null);
+}

--- a/src/Page/Filter/ContentRangeFilter.php
+++ b/src/Page/Filter/ContentRangeFilter.php
@@ -52,7 +52,7 @@ class ContentRangeFilter extends AbstractContentFilter
 		} elseif (null !== $value[RangeFilterForm::MIN]) {
 			$value[RangeFilterForm::MIN] = ($value[RangeFilterForm::MIN] instanceof \DateTime) ?
 				$value[RangeFilterForm::MIN]->getTimestamp() :
-				(float)$value[RangeFilterForm::MIN];
+				(float) $value[RangeFilterForm::MIN];
 		}
 
 		if (!array_key_exists(RangeFilterForm::MAX, $value)) {
@@ -60,7 +60,7 @@ class ContentRangeFilter extends AbstractContentFilter
 		} elseif (null !== $value[RangeFilterForm::MAX]) {
 			$value[RangeFilterForm::MAX] = ($value[RangeFilterForm::MAX] instanceof \DateTime) ?
 				$value[RangeFilterForm::MAX]->getTimestamp() :
-				(float)$value[RangeFilterForm::MAX];
+				(float) $value[RangeFilterForm::MAX];
 		}
 
 		if (count($value) !== 2) {
@@ -88,13 +88,31 @@ class ContentRangeFilter extends AbstractContentFilter
 			}
 			if (null !== $value) {
 				if ($key === RangeFilterForm::MIN) {
-					$queryBuilder->where($this->_getContentAlias() . '.value_string >= ?s', [$this->_value[RangeFilterForm::MIN]]);
+					$queryBuilder->where(
+						$this->_castSQLValue($this->_getContentAlias() . '.value_string') . ' >= ' . $this->_castSQLValue('?s'),
+						[$this->_value[RangeFilterForm::MIN]]);
 				} elseif ($key === RangeFilterForm::MAX) {
-					$queryBuilder->where($this->_getContentAlias() . '.value_string <= ?s', [$this->_value[RangeFilterForm::MAX]]);
+					$queryBuilder->where(
+						$this->_castSQLValue($this->_getContentAlias() . '.value_string') . ' <= ' . $this->_castSQLValue('?s'),
+						[$this->_value[RangeFilterForm::MAX]]);
 				} else {
 					throw new \LogicException('Key `' . $key . '` should not exist on value!');
 				}
 			}
 		}
+	}
+
+	/**
+	 * Get MySQL statement that casts value to a float
+	 * MySQL has a limit on 65 characters for a decimal value, with a maximum of 30 decimal places. This sets the
+	 * maximum values to ensure flexibility
+	 *
+	 * @param $value
+	 *
+	 * @return string
+	 */
+	private function _castSQLValue($value)
+	{
+		return sprintf('CAST(%s as DECIMAL(65,30))', $value);
 	}
 }

--- a/src/Page/Filter/ContentRangeFilter.php
+++ b/src/Page/Filter/ContentRangeFilter.php
@@ -53,13 +53,17 @@ class ContentRangeFilter extends AbstractFilter implements ContentFilterInterfac
 		if (!array_key_exists(RangeFilterForm::MIN, $value)) {
 			$value[RangeFilterForm::MIN] = null;
 		} else {
-			$value[RangeFilterForm::MIN] = (float) $value[RangeFilterForm::MIN];
+			$value[RangeFilterForm::MIN] = ($value[RangeFilterForm::MIN] instanceof \DateTime) ?
+				$value[RangeFilterForm::MIN]->getTimestamp() :
+				(float) $value[RangeFilterForm::MIN];
 		}
 
 		if (!array_key_exists(RangeFilterForm::MAX, $value)) {
 			$value[RangeFilterForm::MAX] = null;
 		} else {
-			$value[RangeFilterForm::MAX] = (float) $value[RangeFilterForm::MAX];
+			$value[RangeFilterForm::MAX] = ($value[RangeFilterForm::MAX] instanceof \DateTime) ?
+				$value[RangeFilterForm::MAX]->getTimestamp() :
+				(float) $value[RangeFilterForm::MAX];
 		}
 
 		if (count($value) !== 2) {
@@ -73,9 +77,15 @@ class ContentRangeFilter extends AbstractFilter implements ContentFilterInterfac
 	{
 		$queryBuilder->leftJoin('page_content', 'page.page_id = page_content.page_id')
 			->where('page_content.field_name = ?s', [$this->_field])
-			->where('page_content.value_string >= ?s', [$this->_value[RangeFilterForm::MIN]])
-			->where('page_content.value_string <= ?s', [$this->_value[RangeFilterForm::MAX]])
 		;
+
+		if (null !== $this->_value[RangeFilterForm::MIN]) {
+			$queryBuilder->where('page_content.value_string >= ?s', [$this->_value[RangeFilterForm::MIN]]);
+		}
+
+		if (null !== $this->_value[RangeFilterForm::MAX]) {
+			$queryBuilder->where('page_content.value_string <= ?s', [$this->_value[RangeFilterForm::MAX]]);
+		}
 
 		if ($this->_group) {
 			$queryBuilder->where('page_content.group_name = ?s', [$this->_group]);

--- a/src/Page/Filter/ContentRangeFilter.php
+++ b/src/Page/Filter/ContentRangeFilter.php
@@ -16,7 +16,7 @@ use Message\Mothership\CMS\Form\RangeFilterForm;
  */
 class ContentRangeFilter extends AbstractContentFilter
 {
-	const CONTENT_ALIAS = 'content_range_filter_pc';
+	protected $_alias = 'content_range_filter_pc';
 
 	/**
 	 * @var array
@@ -98,13 +98,5 @@ class ContentRangeFilter extends AbstractContentFilter
 				}
 			}
 		}
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	protected function _getContentAlias()
-	{
-		return self::CONTENT_ALIAS;
 	}
 }

--- a/src/Page/Filter/ContentRangeFilter.php
+++ b/src/Page/Filter/ContentRangeFilter.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Message\Mothership\CMS\Page\Filter;
+
+use Message\Cog\Filter\AbstractFilter;
+use Message\Cog\DB\QueryBuilderInterface;
+use Message\Mothership\CMS\Form\RangeFilterForm;
+
+/**
+ * Class ContentRangeFilter
+ * @package Message\Mothership\CMS\Page\Filter
+ *
+ * @author  Thomas Marchant <thomas@mothership.ec>
+ */
+class ContentRangeFilter extends AbstractFilter implements ContentFilterInterface
+{
+	/**
+	 * @var string
+	 */
+	protected $_field;
+
+	/**
+	 * @var string
+	 */
+	protected $_group;
+
+	public function getForm()
+	{
+		return new RangeFilterForm;
+	}
+
+	public function setField($field, $group = null)
+	{
+		if (!is_string($field)) {
+			throw new \InvalidArgumentException('Field must be a string, ' . gettype($field) . ' given');
+		}
+
+		if (null !== $group && !is_string($group)) {
+			throw new \InvalidArgumentException('Group must be a string, ' . gettype($group) . ' given');
+		} elseif ($group) {
+			$this->_group = $group;
+		}
+
+		$this->_field = $field;
+	}
+
+	public function setValue($value)
+	{
+		if (!is_array($value)) {
+			throw new \InvalidArgumentException('Value must be an array');
+		}
+
+		if (!array_key_exists(RangeFilterForm::MIN, $value)) {
+			$value[RangeFilterForm::MIN] = null;
+		} else {
+			$value[RangeFilterForm::MIN] = (float) $value[RangeFilterForm::MIN];
+		}
+
+		if (!array_key_exists(RangeFilterForm::MAX, $value)) {
+			$value[RangeFilterForm::MAX] = null;
+		} else {
+			$value[RangeFilterForm::MAX] = (float) $value[RangeFilterForm::MAX];
+		}
+
+		if (count($value) !== 2) {
+			throw new \LogicException('Value array must have only two values, with keys of `' . RangeFilterForm::MIN . '` and `' . RangeFilterForm::MAX . '`');
+		}
+
+		$this->_value = $value;
+	}
+
+	protected function _applyFilter(QueryBuilderInterface $queryBuilder)
+	{
+		$queryBuilder->leftJoin('page_content', 'page.page_id = page_content.page_id')
+			->where('page_content.field_name = ?s', [$this->_field])
+			->where('page_content.value_string >= ?s', [$this->_value[RangeFilterForm::MIN]])
+			->where('page_content.value_string <= ?s', [$this->_value[RangeFilterForm::MAX]])
+		;
+
+		if ($this->_group) {
+			$queryBuilder->where('page_content.group_name = ?s', [$this->_group]);
+		}
+	}
+}

--- a/src/Page/Filter/ContentRangeFilter.php
+++ b/src/Page/Filter/ContentRangeFilter.php
@@ -16,8 +16,6 @@ use Message\Mothership\CMS\Form\RangeFilterForm;
  */
 class ContentRangeFilter extends AbstractContentFilter
 {
-	protected $_alias = 'content_range_filter_pc';
-
 	/**
 	 * @var array
 	 */

--- a/src/Page/Filter/README.md
+++ b/src/Page/Filter/README.md
@@ -11,7 +11,16 @@ controller.
 ### Adding filter options
 
 An instance of `\Message\Cog\Filter\FilterCollection` should be added to the service container of your installation,
-with all the filters added to the constructor in an array.
+with all the filters added to the constructor in an array:
+
+```php
+$services['page_filters'] = function ($c) {
+    return new \Message\Cog\Filter\FilterCollection([
+        $c['foo_filter'],
+        $c['bar_filter'],
+    ]);
+};
+```
 
 In all filters, the first two parameters for the constructor are the name of the form field, followed by the label of
 the form field.
@@ -27,8 +36,9 @@ $services['tag_filter'] = function ($c) {
     $tags = $c['cms.page.tag.loader']->getAll()
 
     $tagFilter->setOptions([
-        'choices' => array_combine($tags, $tags), // Use array combine as the form value is set against the
-                                                  // array key, and the label is set against the array value
+        'choices' => array_combine($tags, $tags), // Use array combine as the form value is
+                                                  // set against the  array key, and the label
+                                                  // is set against the array value
     ]);
 
     return $tagFilter; // Remember to return the filter
@@ -43,14 +53,16 @@ $services['foo_filter'] = function ($c) {
     $fooFilter = new \Message\Mothership\CMS\Page\Filter\ContentFilter(
         'foo_filter',
         'Filter by Foo',
-        $c['db.query.factory.builder'] // Optional third parameter takes instance of \Message\Cog\DB\QueryBuilderFactory
-                                       // to automatically load options. If not set, you will need to add options
+        $c['db.query.factory.builder'] // Optional third parameter takes instance of
+                                       // \Message\Cog\DB\QueryBuilderFactory to automatically
+                                       // load options. If not set, you will need to add options
                                        // manually like with the TagFilter
     );
 
-    $foo->setField('foo'); // Load content in a field called 'foo'. Since no second parameter is added, the filter
-                           // will only apply to fields that are not part of a group. If you wanted to include
-                           // Filters in a group called 'bar', you would call $foo->setField('foo', 'bar');
+    $foo->setField('foo'); // Load content in a field called 'foo'. Since no second parameter is
+                           // added, the filter will only apply to fields that are not part of a
+                           // group. If you wanted to include you would call
+                           // $foo->setField('foo', 'bar');
 
     return $foo;
 };
@@ -59,3 +71,124 @@ $services['foo_filter'] = function ($c) {
 + **ContentRangeFilter** - Identical to `ContentFilter`, except it creates two form fields, and searches for a value
 that falls between the values given for those two fields. The fields will be select drop-downs by default, but can be
 switched to radio buttons by calling `setOptions(['expanded' => true])`
+
+
+### Rendering the filter form
+
+To render the filter form, call the `Message:Mothership:CMS::Controller:Module:PageFilter#filterForm` controller from
+your view file. It takes one parameter, `filters`, which can either be an instance of `FilterCollection`, or the service
+name for the filter collection. So if we were to take the example above an assume our service is called `page_filters`,
+you would add the following to the view:
+
+```twig
+{{ render(controller('Message:Mothership:CMS::Controller:Module:PageFilter#filterForm', {
+	filters: 'page_filters'
+})) }}
+```
+
+### Loading pages using the filter
+
+It is the installation's responsibility to load the pages, and so the developer will need to write a controller if
+one does not already exist when Mothership is installed. This controller will be called via a sub-request, i.e.
+the controller is called within the view, like with the form rendering example above. Much like the example above,
+you would probably want to give the controller the service name for your filters:
+
+```twig
+{{ render(controller('Mothership:Site::Controller:MyController#filterPages', {
+	filters: 'page_filters'
+})) }}
+```
+
+To apply the the filters, get the form instance by calling the `filter.form_factory` service and building the form
+from the `FilterCollection`, bind the form data to the filters using the `filter.data_binder` service, and then
+apply the filters to the page loader, e.g.:
+
+```php
+<?php
+
+namespace Mothership\Site\Controller;
+
+class MyController
+{
+    public function filterPages($filters)
+    {
+        $filters = $this->get($filters); // Get the filters from the service container;
+
+        $form = $this->createForm(
+            $this->get('filter.form_factory')->getForm($filters); // Build the form with the filter
+                                                                  // collection
+        );
+
+        $form->handleRequest(); // Handle the form request to load the submitted data
+
+        if ($form->isValid()) {
+            $data = $form->getData();
+
+            // Bind the data to the filters
+            // Note: this method does not parse by reference, so you will need
+            // to redeclare your filters variable
+            $filters = $this->get('filter.data_binder')->bindData($data, $filters);
+
+            $pageLoader = $this->get('cms.page.loader'); // Get the page loader from the service container
+
+            $pages = $pageLoader->loadFromFilters($filters); // Loads pages as per the data given to the filters
+
+            return $this->render('Mothership:Site::my-view-file', [
+                'pages' => $pages
+            ]);
+        }
+
+        return $this->redirectToReferer();
+    }
+}
+```
+
+If you want to call a different method on the page loader, e.g. `getChildren()`, you can call `applyFilters($filters)`
+instead of `loadFromFilters()`. This will add the filtering to the query, without loading the pages.
+
+### AJAX
+
+To load the filtered results, first include `'@Message:Mothership:CMS::resources/assets/js/filter-pages.js'` to the
+`javascripts` block in the main template.
+
+Add a route to the `\Mothership\Site\Bootstrap\Routes` class to give AJAX a URL to load:
+
+```php
+$router->add(
+        'page_filtering', // The name of the route, to be called from the view
+        '/page-filtering/{filters}', // The URL of the route, with the $filters variable as part of the URL
+        'Mothership:Site::Controller:MyController#filterPages' // The controller to call
+    )
+    ->setMethod('GET') // Setting the method as GET allows URLs to contain the form information (recommended)
+;
+```
+
+From you page view, you can now include a javascript function call to `filterPages()`. This function takes five parameters,
+although only the first two are required:
+
++ **ajaxUrl** - The URL to submit the form to
+* **filterDestinationID** - The container to insert the AJAX-loaded HTML into
+* **method** - The method to submit the form with, only supports `GET` and `POST`, defaults to `GET`
+* **formID** - The ID of the filter form, defaults to `#page-filter-form`
+* **paginationMenuID** - The ID of the pagination menu, if applicable. Defaults to `#pagination-menu`
+
+```html
+<script>
+    <!--
+        Call the url() twig function to generate the URL for the page filter controller. The first parameter
+        is the route name as defined above, and the second parameter is an array of arguments to give the controller.
+        In this case, that array only consists of the $filters variable, which is set to the service name of the
+        FilterCollection
+    -->
+    $(document).ready(function () {
+        filterPages(
+            '{{ url('page-filtering, { filters: 'page_filters'}) }}',
+            '#my-container'
+        );
+    });
+</script>
+```
+
+This function will submit the form data to the controller, and render it within the container with an ID of `my-container`.
+Since we are using the default `GET` method to submit the form, it will also amend the URL in the browser's address bar
+to include the form data. It will also append the form data to any pagination links.

--- a/src/Page/Filter/README.md
+++ b/src/Page/Filter/README.md
@@ -162,7 +162,8 @@ $router->add(
                                      // of the URL
         'Mothership:Site::Controller:MyController#filterPages' // The controller to call
     )
-    ->setMethod('GET') // Setting the method as GET allows URLs to contain the form information (recommended)
+    ->setMethod('GET') // Setting the method as GET allows URLs to contain the form information.
+                       // This is recommended for the purposes of maintaining pagination etc.
 ;
 ```
 

--- a/src/Page/Filter/README.md
+++ b/src/Page/Filter/README.md
@@ -129,9 +129,11 @@ class MyController
             // to redeclare your filters variable
             $filters = $this->get('filter.data_binder')->bindData($data, $filters);
 
-            $pageLoader = $this->get('cms.page.loader'); // Get the page loader from the service container
+            $pageLoader = $this->get('cms.page.loader'); // Get the page loader from the service
+                                                         // container
 
-            $pages = $pageLoader->loadFromFilters($filters); // Loads pages as per the data given to the filters
+            $pages = $pageLoader->loadFromFilters($filters); // Loads pages as per the data given
+                                                             // to the filters
 
             return $this->render('Mothership:Site::my-view-file', [
                 'pages' => $pages
@@ -156,7 +158,8 @@ Add a route to the `\Mothership\Site\Bootstrap\Routes` class to give AJAX a URL 
 ```php
 $router->add(
         'page_filtering', // The name of the route, to be called from the view
-        '/page-filtering/{filters}', // The URL of the route, with the $filters variable as part of the URL
+        '/page-filtering/{filters}', // The URL of the route, with the $filters variable as part
+                                     // of the URL
         'Mothership:Site::Controller:MyController#filterPages' // The controller to call
     )
     ->setMethod('GET') // Setting the method as GET allows URLs to contain the form information (recommended)
@@ -175,10 +178,10 @@ although only the first two are required:
 ```html
 <script>
     <!--
-        Call the url() twig function to generate the URL for the page filter controller. The first parameter
-        is the route name as defined above, and the second parameter is an array of arguments to give the controller.
-        In this case, that array only consists of the $filters variable, which is set to the service name of the
-        FilterCollection
+        Call the url() twig function to generate the URL for the page filter controller.
+        The first parameter is the route name as defined above, and the second parameter is
+        an array of arguments to give the controller. In this case, that array only consists of
+        the $filters variable, which is set to the service name of the FilterCollection
     -->
     $(document).ready(function () {
         filterPages(

--- a/src/Page/Filter/README.md
+++ b/src/Page/Filter/README.md
@@ -1,0 +1,61 @@
+# CMS Filters
+
+This library uses the Cog `Filter` component to allow pages to be loaded as per user input on a filter form. It is
+designed to work in conjunction with the `filter-pages.js` file.
+
+A controller is included to render the form, but the page loading itself is the role of the installation-level
+controller.
+
+## Usage
+
+### Adding filter options
+
+An instance of `\Message\Cog\Filter\FilterCollection` should be added to the service container of your installation,
+with all the filters added to the constructor in an array.
+
+In all filters, the first two parameters for the constructor are the name of the form field, followed by the label of
+the form field.
+
+There are three types of filter in this library:
+
++ **TagFilter** - Filters by tag. Tags are not automatically added as choices, and need to be added manually via the
+`setOptions()` method:
+
+```php
+$services['tag_filter'] = function ($c) {
+    $tagFilter = new \Message\Mothership\CMS\Page\Filter\TagFilter('tag_filter', 'Filter by Tag');
+    $tags = $c['cms.page.tag.loader']->getAll()
+
+    $tagFilter->setOptions([
+        'choices' => array_combine($tags, $tags), // Use array combine as the form value is set against the
+                                                  // array key, and the label is set against the array value
+    ]);
+
+    return $tagFilter; // Remember to return the filter
+};
+```
+
++ **ContentFilter** - Filters by a content field set against the page. For instance if you wanted to filter by a field
+called 'foo', you would add the filter like this:
+
+```php
+$services['foo_filter'] = function ($c) {
+    $fooFilter = new \Message\Mothership\CMS\Page\Filter\ContentFilter(
+        'foo_filter',
+        'Filter by Foo',
+        $c['db.query.factory.builder'] // Optional third parameter takes instance of \Message\Cog\DB\QueryBuilderFactory
+                                       // to automatically load options. If not set, you will need to add options
+                                       // manually like with the TagFilter
+    );
+
+    $foo->setField('foo'); // Load content in a field called 'foo'. Since no second parameter is added, the filter
+                           // will only apply to fields that are not part of a group. If you wanted to include
+                           // Filters in a group called 'bar', you would call $foo->setField('foo', 'bar');
+
+    return $foo;
+};
+```
+
++ **ContentRangeFilter** - Identical to `ContentFilter`, except it creates two form fields, and searches for a value
+that falls between the values given for those two fields. The fields will be select drop-downs by default, but can be
+switched to radio buttons by calling `setOptions(['expanded' => true])`

--- a/src/Page/Filter/TagFilter.php
+++ b/src/Page/Filter/TagFilter.php
@@ -5,8 +5,19 @@ namespace Message\Mothership\CMS\Page\Filter;
 use Message\Cog\Filter\AbstractFilter;
 use Message\Cog\DB\QueryBuilderInterface;
 
+/**
+ * Class TagFilter
+ * @package Message\Mothership\CMS\Page\Filter
+ *
+ * @author  Thomas Marchant <thomas@mothership.ec>
+ *
+ * Class for filtering pages by tag
+ */
 class TagFilter extends AbstractFilter
 {
+	/**
+	 * {@inheritDoc}
+	 */
 	public function setValue($value)
 	{
 		if (!is_array($value)) {
@@ -16,6 +27,9 @@ class TagFilter extends AbstractFilter
 		$this->_value = $value;
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	protected function _applyFilter(QueryBuilderInterface $queryBuilder)
 	{
 		if (empty($this->_value)) {

--- a/src/Page/Filter/TagFilter.php
+++ b/src/Page/Filter/TagFilter.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Message\Mothership\CMS\Page\Filter;
+
+use Message\Cog\Filter\AbstractFilter;
+use Message\Cog\DB\QueryBuilderInterface;
+
+class TagFilter extends AbstractFilter
+{
+	public function setValue($value)
+	{
+		if (!is_string($value)) {
+			throw new \LogicException('Value must be a string');
+		}
+
+		$this->_value = $value;
+	}
+
+	protected function _applyFilter(QueryBuilderInterface $queryBuilder)
+	{
+		$queryBuilder->leftJoin('page_tag', 'page.page_id = page_tag.page_id')
+			->where('page_tage.tag_name = ?s', $this->_value)
+		;
+	}
+}

--- a/src/Page/Filter/TagFilter.php
+++ b/src/Page/Filter/TagFilter.php
@@ -9,8 +9,8 @@ class TagFilter extends AbstractFilter
 {
 	public function setValue($value)
 	{
-		if (!is_string($value)) {
-			throw new \LogicException('Value must be a string');
+		if (!is_array($value)) {
+			throw new \LogicException('Tag filter value must be an array');
 		}
 
 		$this->_value = $value;
@@ -18,8 +18,12 @@ class TagFilter extends AbstractFilter
 
 	protected function _applyFilter(QueryBuilderInterface $queryBuilder)
 	{
-		$queryBuilder->leftJoin('page_tag', 'page.page_id = page_tag.page_id')
-			->where('page_tage.tag_name = ?s', $this->_value)
+		if (empty($this->_value)) {
+			return;
+		}
+
+		$queryBuilder->leftJoin('page_tag', 'page_tag.page_id = page.page_id')
+			->where('page_tag.tag_name IN (?js)', [$this->_value])
 		;
 	}
 }

--- a/src/Page/Loader.php
+++ b/src/Page/Loader.php
@@ -351,10 +351,6 @@ class Loader
 				;
 			}
 		} else {
-			if (null !== $this->_queryBuilder) {
-				throw new \LogicException('Cannot load siblings without resetting query builder');
-			}
-
 			// Don't try this at home. Since the QueryBuilder doesn't allow us to parse variables in
 			// ON statements, I am casting the page depth to an integer here to give to the query
 			// directly.
@@ -379,6 +375,7 @@ class Loader
 			$this->_queryBuilder
 				->join('siblings', 'siblings.page_id = page.page_id', $subQuery)
 			;
+
 		}
 
 		return $this->_loadPages();

--- a/src/Page/Loader.php
+++ b/src/Page/Loader.php
@@ -134,9 +134,9 @@ class Loader
 	{
 		if (!is_array($pageIDs)) {
 			$pageIDs = [$pageIDs];
-			$this->_returnAsArray = true;
-		} else {
 			$this->_returnAsArray = false;
+		} else {
+			$this->_returnAsArray = true;
 		}
 
 		$this->_buildQuery();

--- a/src/Page/TagLoader.php
+++ b/src/Page/TagLoader.php
@@ -4,41 +4,53 @@ namespace Message\Mothership\CMS\Page;
 
 use Message\Cog\Field;
 
-use Message\Cog\DB\Query as DBQuery;
-use Message\Cog\DB\Result as DBResult;
+use Message\Cog\DB\QueryBuilderFactory;
 use Message\Cog\DB\Entity\EntityLoaderInterface;
-use Message\Cog\Field\Factory;
 
 /**
  * Loads page tags by page.
  * 
  * @author Iris Schaffer <iris@message.co.uk>
+ * @author Thomas Marchant <thomas@message.co.uk>
  */
 class TagLoader implements EntityLoaderInterface
 {
-	protected $_query;
+	private $_queryBuilderFactory;
 
 	/**
 	 * Constructor.
 	 *
-	 * @param DBQuery       $query     The database query instance to use
+	 * @param QueryBuilderFactory $queryBuilderFactory        The database query instance to use
 	 */
-	public function __construct(DBQuery $query)
+	public function __construct(QueryBuilderFactory $queryBuilderFactory)
 	{
-		$this->_query = $query;
+		$this->_queryBuilderFactory = $queryBuilderFactory;
 	}
 
 	public function load(Page $page)
 	{
-		$tags = $this->_query->run('
-			SELECT
-				tag_name
-			FROM
-				page_tag
-			WHERE
-				page_id = ?i
-		', $page->id);
+		return $this->_getQueryBuilder()
+			->where('page_id = ?i', [$page->id])
+			->getQuery()
+			->run()
+			->flatten()
+		;
+	}
 
-		return $tags->flatten();
+	public function getAll()
+	{
+		return $this->_getQueryBuilder()
+			->getQuery()
+			->run()
+			->flatten()
+		;
+	}
+
+	private function _getQueryBuilder()
+	{
+		return $this->_queryBuilderFactory->getQueryBuilder()
+			->select('tag_name')
+			->from('page_tag')
+		;
 	}
 }

--- a/translations/en.yml
+++ b/translations/en.yml
@@ -227,6 +227,9 @@ ms.cms:
       ip: IP address
       comment: Comment
       status: Status
+  page_filter:
+    min: From
+    max: To
 page:
   blog:
     comments:


### PR DESCRIPTION
This PR implements page filtering functionality using the new Filter component in Cog (https://github.com/mothership-ec/cog/pull/440)

A side effect of this is a total overhaul of the page loader to use the QueryBuilder instead of straight up queries, which is a refactor that has been on the cards for a long time coming

## Includes:

+ `Page\Filter` namespace
+ `TagFilter` class for filtering pages by their tags
+ `ContentFilter` class for filtering by content fields
+ `ContentRangeFilter` class for filtering for pages with content that falls between two values
+ `ContentFilterInterface` interface for classes that filter by content, implemented by `ContentFilter` and `ContentRangeFilter`
+ `AbstractContentFilter` abstract class extended by `ContentFilter` and `ContentRangeFilter`
+ `RangeFilterForm` class, a simple form that contains two matching drop downs for filtering by range
+ Controller for rendering filter form
+ `filter-pages.js` file for handling AJAX requests to load content fields, and amending URLs to match form data (if method is set to `GET`)
+ Complete refactor of `Page\Loader` class to use `QueryBuilder`

## BC breaks -

+ Constructor for `Page\Loader` has changed. This should be fine as it would only ever be accessed via the service container