### PR TITLE
Feature/slug validation

### DIFF
--- a/src/Bootstrap/Routes.php
+++ b/src/Bootstrap/Routes.php
@@ -3,6 +3,7 @@
 namespace Message\Mothership\CMS\Bootstrap;
 
 use Message\Cog\Bootstrap\RoutesInterface;
+use Message\Mothership\CMS\Page\Page;
 
 class Routes implements RoutesInterface
 {
@@ -21,7 +22,7 @@ class Routes implements RoutesInterface
 
 		// Be sure to put front end routes *before* this line (as with contact form and comments above)
 		$router['ms.cms']->add('ms.cms.frontend', '{slug}', 'Message:Mothership:CMS::Controller:Frontend#renderPage')
-			->setRequirement('slug', '[a-z0-9\-\/]+')
+			->setRequirement('slug', trim(Page::SLUG_PATTERN, '/'))
 			->setDefault('slug', '/');
 
 		$router['ms.cms']->add('ms.cms.broken_link.action', '/broken_link', 'Message:Mothership:CMS::Controller:Module:Form#brokenLinkAction')

--- a/src/Controller/ControlPanel/Edit.php
+++ b/src/Controller/ControlPanel/Edit.php
@@ -565,6 +565,7 @@ class Edit extends \Message\Cog\Controller\Controller
 			// continue if the frontend route is the most promenant
 			if ($routes['_route'] !== 'ms.cms.frontend') {
 				$this->addFlash('error',  $this->trans('ms.cms.feedback.force-slug.failure.reserved-route'));
+				$update = false;
 			}
 		} catch (\Symfony\Component\Routing\Exception\ResourceNotFoundException $e) {	
 			$this->addFlash('error', $this->trans('ms.cms.feedback.force-slug.failure.not-matched'));
@@ -572,7 +573,7 @@ class Edit extends \Message\Cog\Controller\Controller
 		}
 
 		// If not slug has been found, we need to check the history too
-		if (!$checkSlug) {
+		if (!$checkSlug && $update) {
 			// Check for the slug historicaly and show deleted ones too
 			$historicalSlug = $this->get('cms.page.loader')
 				->includeDeleted(true)

--- a/src/Controller/ControlPanel/Edit.php
+++ b/src/Controller/ControlPanel/Edit.php
@@ -567,7 +567,8 @@ class Edit extends \Message\Cog\Controller\Controller
 				$this->addFlash('error',  $this->trans('ms.cms.feedback.force-slug.failure.reserved-route'));
 			}
 		} catch (\Symfony\Component\Routing\Exception\ResourceNotFoundException $e) {	
-			// no route found so we can continue
+			$this->addFlash('error', $this->trans('ms.cms.feedback.force-slug.failure.not-matched'));
+			$update = false;
 		}
 
 		// If not slug has been found, we need to check the history too

--- a/src/Controller/ControlPanel/Edit.php
+++ b/src/Controller/ControlPanel/Edit.php
@@ -559,6 +559,17 @@ class Edit extends \Message\Cog\Controller\Controller
 		$slug = '/'.implode('/',$slugSegments);
 		$checkSlug = $this->get('cms.page.loader')->getBySlug($slug, false);
 
+		try {
+			$routes = $this->get('routing.matcher')->match($slug);
+
+			// continue if the frontend route is the most promenant
+			if ($routes['_route'] !== 'ms.cms.frontend') {
+				$this->addFlash('error',  $this->trans('ms.cms.feedback.force-slug.failure.reserved-route'));
+			}
+		} catch (\Symfony\Component\Routing\Exception\ResourceNotFoundException $e) {	
+			// no route found so we can continue
+		}
+
 		// If not slug has been found, we need to check the history too
 		if (!$checkSlug) {
 			// Check for the slug historicaly and show deleted ones too
@@ -623,7 +634,9 @@ class Edit extends \Message\Cog\Controller\Controller
 			try {
 				$page = $this->get('cms.page.edit')->updateSlug($page, $newSlug);
 			} catch (InvalidSlugException $e) {
-				$this->addFlash('error', 'Could not update slug. ' . $e->getMessage());
+				$this->addFlash('error', $this->trans('ms.cms.feedback.force-slug.failure.generic', [
+					'%message%' => $e->getMessage(),
+				]));
 			}
 		}
 

--- a/src/Controller/ControlPanel/Edit.php
+++ b/src/Controller/ControlPanel/Edit.php
@@ -12,6 +12,7 @@ use Message\Mothership\CMS\Page\Exception\PageEditException;
 
 use Message\Cog\ValueObject\Slug;
 use Message\Mothership\FileManager\File;
+use Message\Mothership\CMS\Page\Exception\InvalidSlugException;
 
 class Edit extends \Message\Cog\Controller\Controller
 {
@@ -384,7 +385,7 @@ class Edit extends \Message\Cog\Controller\Controller
 		else {
 			$form->add('slug', 'text', $this->trans('ms.cms.attributes.slug.label'), array(
 				'read_only' => true,
-				'data' => $this->trans('ms.cms.attributes.slug.homepage')
+				'data' => $this->trans('ms.cms.attributes.slug.homepage'),
 			));
 		}
 
@@ -619,7 +620,11 @@ class Edit extends \Message\Cog\Controller\Controller
 		// If the slug has changed then update the slug
 		if ($update && $page->slug->getLastSegment() != $newSlug) {
 			$this->get('cms.page.edit')->removeHistoricalSlug($slug);
-			$page = $this->get('cms.page.edit')->updateSlug($page, $newSlug);
+			try {
+				$page = $this->get('cms.page.edit')->updateSlug($page, $newSlug);
+			} catch (InvalidSlugException $e) {
+				$this->addFlash('error', 'Could not update slug. ' . $e->getMessage());
+			}
 		}
 
 		// return the updated or unchanged page

--- a/src/Page/Edit.php
+++ b/src/Page/Edit.php
@@ -137,6 +137,8 @@ class Edit implements TransactionalInterface
 	 * @param  Page   $page    	Page object to udpate
 	 * @param  string $newSlug  The new slug to update
 	 *
+	 * @throws  Exception\InvalidSlugException If the slug is invalid this will be thrown.
+	 *
 	 * @return Page          	Return the updated Page object
 	 */
 	public function updateSlug(Page $page, $newSlug)

--- a/src/Page/Edit.php
+++ b/src/Page/Edit.php
@@ -141,9 +141,14 @@ class Edit implements TransactionalInterface
 	 */
 	public function updateSlug(Page $page, $newSlug)
 	{
+		if (!preg_match(Page::SLUG_PATTERN, $newSlug)) {
+			throw new Exception\InvalidSlugException('Slug must only be formed of alphanumeric characters and hyphens.');
+		}
+
 		// Get all the segements
 		$segements = $page->slug->getSegments();
 		$date = new DateTimeImmutable;
+
 		$this->_transaction->run('
 			REPLACE INTO
 				page_slug_history

--- a/src/Page/Exception/InvalidSlugException.php
+++ b/src/Page/Exception/InvalidSlugException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Message\Mothership\CMS\Page\Exception;
+
+/**
+ * Class PageEditException
+ *
+ * @author Samuel Trangmar-Keates <sam@mothership.ec>
+ */
+class InvalidSlugException extends PageEditException
+{
+
+}

--- a/src/Page/Page.php
+++ b/src/Page/Page.php
@@ -17,6 +17,7 @@ use Message\Cog\ValueObject\DateTimeImmutable;
 class Page
 {
 	const SLUG_PATTERN = '/^[a-z0-9\-\/]+$/';
+
 	public $locale;
 	public $authorship;
 

--- a/src/Page/Page.php
+++ b/src/Page/Page.php
@@ -16,6 +16,7 @@ use Message\Cog\ValueObject\DateTimeImmutable;
  */
 class Page
 {
+	const SLUG_PATTERN = '/^[a-z0-9\-\/]+$/';
 	public $locale;
 	public $authorship;
 

--- a/translations/en.yml
+++ b/translations/en.yml
@@ -37,6 +37,8 @@ ms.cms:
         deleted: The url <code>%slug%</code> is saved against a page which has been deleted. Would you like to use this url anyway? <a href="%forceUrl%">Yes</a>
         redirected: The url <code>%slug%</code> has been used in the past and is being redirected to <a href="%redirectedUrl%">%redirectedTitle%</a>. Would you like to use this url anyway? <a href="%forceUrl%">Yes please!</a>
         already-used: The url <code>%slugUrl%</code> is already in use on the page <a href="%usingUrl%">%usingTitle%</a>
+        reserved-route: This route is already reserved by a module.
+        generic: Error updating slug: %message%
       success: The Url was successfully updated
   repeatable_group:
     add: "{0} Add a %name%|[1,Inf] Add another %name%"

--- a/translations/en.yml
+++ b/translations/en.yml
@@ -39,6 +39,7 @@ ms.cms:
         already-used: The url <code>%slugUrl%</code> is already in use on the page <a href="%usingUrl%">%usingTitle%</a>
         reserved-route: This route is already reserved by a module.
         generic: Error updating slug: %message%
+        not-matched: The slug given does not match the requirements. Please use only alphanumeric characters and hyphens.
       success: The Url was successfully updated
   repeatable_group:
     add: "{0} Add a %name%|[1,Inf] Add another %name%"


### PR DESCRIPTION
Adds Validation to the slug edit action to prevent slugs such as `/admin` being saved. It also adds validation via regex to prevent users saving a slug such as `__hi` as underscores are not supported. This fixes #239.

Test by trying to enter some invalid slugs.