### PR TITLE
added placeholders to range filter form

### DIFF
--- a/src/Form/RangeFilterForm.php
+++ b/src/Form/RangeFilterForm.php
@@ -14,35 +14,56 @@ class RangeFilterForm extends AbstractType
 	const MIN_LABEL = 'ms.cms.page_filter.min';
 	const MAX_LABEL = 'ms.cms.page_filter.max';
 
+	/**
+	 * {@inheritDoc}
+	 */
 	public function getName()
 	{
 		return 'cms_page_range_filter';
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	public function buildForm(FormBuilderInterface $builder, array $options)
 	{
 		$builder->add(self::MIN, 'choice', [
-			'label'    => $options['min_label'],
-			'choices'  => $options['choices'],
-			'multiple' => false,
-			'expanded' => $options['expanded'],
+			'label'       => $options['min_label'],
+			'choices'     => $options['choices'],
+			'multiple'    => false,
+			'expanded'    => $options['expanded'],
+			'empty_value' => $options['min_placeholder']
 		]);
 
 		$builder->add(self::MAX, 'choice', [
-			'label'    => $options['max_label'],
-			'choices'  => $options['choices'],
-			'multiple' => false,
-			'expanded' => $options['expanded'],
+			'label'       => $options['max_label'],
+			'choices'     => $options['choices'],
+			'multiple'    => false,
+			'expanded'    => $options['expanded'],
+			'empty_value' => $options['max_placeholder']
 		]);
 	}
 
+	/**
+	 * {@inheritDoc}
+	 *
+	 * Options:
+	 * 	- `min_label`         Label for minimum selector field
+	 *  - `max_label`         Label for maximum selector field
+	 *  - `min_placeholder`   Placeholder for minimum selector field
+	 *  - `max_placeholder`   Placeholder for maximum selector field
+	 *  - `choices`           Choices to be assigned to both selector fields
+	 *  - `expanded`          Set as `false` for select drop down, and `true` for radio buttons
+	 */
 	public function setDefaultOptions(OptionsResolverInterface $resolver)
 	{
 		$resolver->setDefaults([
-			'min_label' => self::MIN_LABEL,
-			'max_label' => self::MAX_LABEL,
-			'choices'   => [],
-			'expanded'  => false,
+			'min_label'       => self::MIN_LABEL,
+			'max_label'       => self::MAX_LABEL,
+			'min_placeholder' => null,
+			'max_placeholder' => null,
+			'choices'         => [],
+			'expanded'        => false,
 		]);
 	}
 }


### PR DESCRIPTION
This PR adds options to add placeholders to the `RangeFilterForm` fields by adding `min_placeholder` and `max_placeholder` options