### PR TITLE
getAll() method on page loader returns as array

### DIFF
--- a/src/Page/Loader.php
+++ b/src/Page/Loader.php
@@ -311,6 +311,8 @@ class Loader
 	 */
 	public function getAll()
 	{
+		$this->_returnAsArray = true;
+
 		$this->_buildQuery();
 
 		return $this->_loadPages();


### PR DESCRIPTION
`getAll()` on the page loader wasn't set to return as an array, so if only one page existed the sidebar would break in the CMS