### PR TITLE
Social links for tumblr and pinterest

### DIFF
--- a/resources/fixtures/config/social.yml
+++ b/resources/fixtures/config/social.yml
@@ -16,3 +16,21 @@ linked-in:
 tumblr:
   name: # name
   slug: # slug to link to
+google-plus:
+  name: # name
+  slug: # slug to link to
+soundcloud:
+  name: # name
+  slug: # slug to link to
+bandcamp:
+  name: # name
+  slug: # slug to link to
+youtube:
+  name: # name
+  slug: # slug to link to
+vimeo:
+  name: # name
+  slug: # slug to link to
+reddit:
+  name: # name
+  slug: # slug to link to

--- a/resources/fixtures/config/social.yml
+++ b/resources/fixtures/config/social.yml
@@ -31,6 +31,6 @@ youtube:
 vimeo:
   name: # name
   slug: # slug to link to
-reddit:
+github:
   name: # name
   slug: # slug to link to

--- a/resources/fixtures/config/social.yml
+++ b/resources/fixtures/config/social.yml
@@ -13,3 +13,6 @@ pinterest:
 linked-in:
   name: # name
   slug: # slug to link to
+tumblr:
+  name: # name
+  slug: # slug to link to

--- a/resources/view/modules/social/links.html.twig
+++ b/resources/view/modules/social/links.html.twig
@@ -1,32 +1,79 @@
 <ul class="social">
-	{% if not social.twitter.name is empty %}
-	<li class="twitter">
-		<a href="https://twitter.com/{{ social.twitter.slug|default(social.twitter.name)|e('url') }}">Twitter</a>
-	</li>
-	{% endif %}
-	{% if not social.instagram.name is empty %}
-	<li class="instagram">
-		<a href="http://instagram.com/{{ social.instagram.slug|default(social.instagram.name)|e('url') }}">Instagram</a>
-	</li>
-	{% endif %}
-	{% if not social.facebook.name is empty %}
-	<li class="facebook">
-		<a href="https://www.facebook.com/{{ social.facebook.slug|default(social.facebook.name)|e('url') }}">Facebook</a>
-	</li>
-	{% endif %}
-	{% if not social.pinterest.name is empty %}
-	<li class="pinterest">
-		<a href="http://www.pinterest.com/{{ social.pinterest.slug|default(social.pinterest.name)|e('url') }}">Pinterest</a>
-	</li>
-	{% endif %}
-	{% if not social.linkedIn.name is empty %}
-	<li class="linkedin">
-		<a href="http://www.linkedin.com/{{ social.linkedIn.slug|default(social.linkedIn.name) }}">LinkedIn</a>
-	</li>
-	{% endif %}
-	{% if not social.tumblr.name is empty %}
-	<li class="tumblr">
-		<a href="http://{{ social.tumblr.slug|default(social.tumblr.name) }}.tumblr.com">Tumblr</a>
-	</li>
-	{% endif %}
+	{% for network in networks %}
+		{% if not social.twitter.name is empty and network == 'twitter' %}
+
+			<li class="twitter">
+				<a href="https://twitter.com/{{ social.twitter.slug|default(social.twitter.name)|e('url') }}">Twitter</a>
+			</li>
+		
+		{% elseif not social.instagram.name is empty and network == 'instagram' %}
+
+			<li class="instagram">
+				<a href="http://instagram.com/{{ social.instagram.slug|default(social.instagram.name)|e('url') }}">Instagram</a>
+			</li>
+		
+		{% elseif not social.facebook.name is empty and network == 'facebook' %}
+
+			<li class="facebook">
+				<a href="https://www.facebook.com/{{ social.facebook.slug|default(social.facebook.name)|e('url') }}">Facebook</a>
+			</li>
+		
+		{% elseif not social.pinterest.name is empty and network == 'pinterest' %}
+
+			<li class="pinterest">
+				<a href="https://www.pinterest.com/{{ social.pinterest.slug|default(social.pinterest.name)|e('url') }}">Pinterest</a>
+			</li>
+		
+		{% elseif not social.linkedIn.name is empty and (network == 'linked-in' or network == 'linkedIn')  %}
+
+			<li class="linkedin">
+				<a href="http://www.linkedin.com/{{ social.linkedIn.slug|default(social.linkedIn.name) }}">LinkedIn</a>
+			</li>
+		
+		{% elseif not social.googlePlus.name is empty and (network == 'google-plus' or network == 'googlePlus')  %}
+
+			<li class="googleplus">
+				<a href="https://plus.google.com/{{ social.googlePlus.slug|default(social.googlePlus.name) }}">Google+</a>
+			</li>
+
+		{% elseif not social.soundcloud.name is empty and network == 'soundcloud'  %}
+
+			<li class="soundcloud">
+				<a href="https://soundcloud.com/{{ social.soundcloud.slug|default(social.soundcloud.name) }}">Soundcloud</a>
+			</li>
+
+		{% elseif not social.bandcamp.name is empty and network == 'bandcamp'  %}
+
+			<li class="bandcamp">
+				{% if social.bandcamp.slug %}
+					<a href="https://bandcamp.com/{{ social.bandcamp.slug }}">Bandcamp</a>
+				{% else %}
+					<a href="https://{{ social.bandcamp.name }}.bandcamp.com">Bandcamp</a>
+				{% endif %}
+			</li>
+
+		{% elseif not social.youtube.name is empty and network == 'youtube'  %}
+
+			<li class="youtube">
+				<a href="https://youtube.com/{{ social.youtube.slug|default('user/' ~ social.youtube.name) }}">Youtube</a>
+			</li>
+
+		{% elseif not social.vimeo.name is empty and network == 'vimeo'  %}
+
+			<li class="vimeo">
+				<a href="https://vimeo.com/{{ social.vimeo.slug|default(social.vimeo.name) }}">Vimeo</a>
+			</li>
+		
+		{% elseif not social.tumblr.name is empty and network == 'tumblr' %}
+
+			<li class="tumblr">
+				{% if social.tumblr.slug %}
+					<a href="https://tumblr.com/{{ social.tumblr.slug }}">Tumblr</a>
+				{% else %}
+					<a href="https://{{ social.tumblr.name }}.tumblr.com">Tumblr</a>
+				{% endif %}
+			</li>
+		
+		{% endif %}
+	{% endfor %}
 </ul>

--- a/resources/view/modules/social/links.html.twig
+++ b/resources/view/modules/social/links.html.twig
@@ -24,4 +24,9 @@
 		<a href="http://www.linkedin.com/{{ social.linkedIn.slug|default(social.linkedIn.name) }}">LinkedIn</a>
 	</li>
 	{% endif %}
+	{% if not social.tumblr.name is empty %}
+	<li class="tumblr">
+		<a href="http://{{ social.tumblr.slug|default(social.tumblr.name) }}.tumblr.com">Tumblr</a>
+	</li>
+	{% endif %}
 </ul>

--- a/resources/view/modules/social/links.html.twig
+++ b/resources/view/modules/social/links.html.twig
@@ -73,6 +73,12 @@
 					<a href="https://{{ social.tumblr.name }}.tumblr.com">Tumblr</a>
 				{% endif %}
 			</li>
+
+		{% elseif not social.github.name is empty and network == 'tumblr' %}
+
+			<li class="github">
+				<a href="https://github.com/{{ social.github.slug|default(social.github.name) }}">Vimeo</a>
+			</li>
 		
 		{% endif %}
 	{% endfor %}

--- a/resources/view/modules/social/links.html.twig
+++ b/resources/view/modules/social/links.html.twig
@@ -77,7 +77,7 @@
 		{% elseif not social.github.name is empty and network == 'github' %}
 
 			<li class="github">
-				<a href="https://github.com/{{ social.github.slug|default(social.github.name) }}">Vimeo</a>
+				<a href="https://github.com/{{ social.github.slug|default(social.github.name) }}">Github</a>
 			</li>
 		
 		{% endif %}

--- a/resources/view/modules/social/links.html.twig
+++ b/resources/view/modules/social/links.html.twig
@@ -74,7 +74,7 @@
 				{% endif %}
 			</li>
 
-		{% elseif not social.github.name is empty and network == 'tumblr' %}
+		{% elseif not social.github.name is empty and network == 'github' %}
 
 			<li class="github">
 				<a href="https://github.com/{{ social.github.slug|default(social.github.name) }}">Vimeo</a>

--- a/resources/view/modules/social/share.html.twig
+++ b/resources/view/modules/social/share.html.twig
@@ -1,22 +1,69 @@
+{% set onclick = 'window.open(this.href, \'sharewin\', \'left=20,top=20,width=500,height=500,toolbar=1,resizable=0\'); return false;' %}
+
 <ul class="social">
-	{% if 'twitter' in networks %}
-		<li class="twitter">
-			<a href="https://twitter.com/share?url={{ uri|e('url') }}&amp;text={{ title|e('url') }}{% if not social.twitter.name is empty %}&amp;via={{ social.twitter.name }}{% endif %}">Twitter</a>
-		</li>
-	{% endif %}
-	{% if 'facebook' in networks %}
-		<li class="facebook">
-			<a href="http://www.facebook.com/sharer.php?s=100&amp;p[url]={{ uri|e('url') }}&amp;p[images][0]={{ imageUri|e('url') }}&amp;p[title]={{ title|e('url') }}&amp;p[summary]={{ description|raw|striptags|e('url') }}">Facebook</a>
-		</li>
-	{% endif %}
-	{% if 'pinterest' in networks %}
-		<li class="pinterest">
-			<a href="http://pinterest.com/pin/create/button/?url={{ uri|e('url') }}&amp;media={{ imageUri|e('url') }}&amp;description={{ description|raw|striptags|e('url') }}">Pinterest</a>
-		</li>
-	{% endif %}
-	{% if 'tumblr' in networks %}
-		<li class="tumblr">
-			<a href="http://www.tumblr.com/share/link?url=url={{ uri|e('url') }}&amp;description={{ description|raw|striptags|e('url') }}">Tumblr</a>
-		</li>
-	{% endif %}
+	{% for network in networks %}
+		{% if network == 'twitter' %}
+			<li class="twitter">
+				<a href="https://twitter.com/share?url={{ uri|e('url') }}&amp;text={{ title|e('url') }}{% if not social.twitter.name is empty %}&amp;via={{ social.twitter.name }}{% endif %}"
+					onclick="{{ onclick }}">
+					Twitter
+				</a>
+			</li>
+
+		{% elseif network == 'facebook' %}
+			
+			<li class="facebook">
+				<a href="http://www.facebook.com/sharer.php?s=100&amp;p[url]={{ uri|e('url') }}&amp;p[images][0]={{ imageUri|e('url') }}&amp;p[title]={{ title|e('url') }}&amp;p[summary]={{ description|raw|striptags|e('url') }}"
+					onclick="{{ onclick }}">
+					Facebook
+				</a>
+			</li>
+
+		{% elseif network == 'pinterest' %}
+
+			<li class="pinterest">
+				<a href="http://pinterest.com/pin/create/button/?url={{ uri|e('url') }}&amp;media={{ imageUri|e('url') }}&amp;description={{ description|raw|striptags|e('url') }}"
+					onclick="{{ onclick }}">
+					Pinterest
+				</a>
+			</li>
+
+		{% elseif network == 'tumblr' %}
+
+			<li class="tumblr">
+				<a href="http://www.tumblr.com/share/link?url={{ uri|e('url') }}&amp;description={{ description|raw|striptags|e('url') }}"
+					onclick="{{ onclick }}">
+					Tumblr
+				</a>
+			</li>
+
+		{% elseif network == 'google-plus' or network == 'googlePlus' %}
+
+			<li class="google-plus">
+				<a href="https://plus.google.com/share?url={{ uri|e('url') }}"
+					onclick="{{ onclick }}">
+					Google+
+				</a>
+			</li>
+
+		{% elseif network == 'linked-in' or network == 'linkedIn' %}
+			
+			<li class="linked-in">
+				<a href="https://www.linkedin.com/shareArticle?mini=true&amp;url={{ uri|e('url') }}"
+					onclick="{{ onclick }}">
+					LinkedIn
+				</a>
+			</li>
+
+		{% elseif network == 'reddit' %}
+
+			<li class="reddit">
+				<a href="http://reddit.com/submit?url={{ uri|e('url') }}&amp;title={{ title|e('url') }}"
+					onclick="{{ onclick }}">
+					Reddit
+				</a>
+			</li>
+
+		{% endif %}
+	{% endfor %}
 </ul>

--- a/resources/view/modules/social/share.html.twig
+++ b/resources/view/modules/social/share.html.twig
@@ -4,7 +4,7 @@
 	{% for network in networks %}
 		{% if network == 'twitter' %}
 			<li class="twitter">
-				<a href="https://twitter.com/share?url={{ uri|e('url') }}&amp;text={{ title|e('url') }} - {{ description }}{% if not social.twitter.name is empty %}&amp;via={{ social.twitter.name }}{% endif %}"
+				<a href="https://twitter.com/share?url={{ uri|e('url') }}&amp;text={{ title|e('url') }}{% if not description is empty %}{{ (' - ' ~ description)|raw|striptags|e('url') }}{% endif %}{% if not social.twitter.name is empty %}&amp;via={{ social.twitter.name }}{% endif %}"
 					onclick="{{ onclick }}">
 					Twitter
 				</a>

--- a/resources/view/modules/social/share.html.twig
+++ b/resources/view/modules/social/share.html.twig
@@ -4,7 +4,7 @@
 	{% for network in networks %}
 		{% if network == 'twitter' %}
 			<li class="twitter">
-				<a href="https://twitter.com/share?url={{ uri|e('url') }}&amp;text={{ title|e('url') }}{% if not social.twitter.name is empty %}&amp;via={{ social.twitter.name }}{% endif %}"
+				<a href="https://twitter.com/share?url={{ uri|e('url') }}&amp;text={{ title|e('url') }} - {{ description }}{% if not social.twitter.name is empty %}&amp;via={{ social.twitter.name }}{% endif %}"
 					onclick="{{ onclick }}">
 					Twitter
 				</a>

--- a/resources/view/modules/social/share.html.twig
+++ b/resources/view/modules/social/share.html.twig
@@ -49,7 +49,7 @@
 		{% elseif network == 'linked-in' or network == 'linkedIn' %}
 			
 			<li class="linked-in">
-				<a href="https://www.linkedin.com/shareArticle?mini=true&amp;url={{ uri|e('url') }}"
+				<a href="https://www.linkedin.com/shareArticle?mini=true&amp;url={{ uri|e('url') }}&amp;title={{ title|e('url') }}&amp;summary={{ description|raw|striptags|e('url') }}"
 					onclick="{{ onclick }}">
 					LinkedIn
 				</a>

--- a/resources/view/modules/social/share.html.twig
+++ b/resources/view/modules/social/share.html.twig
@@ -1,8 +1,22 @@
 <ul class="social">
-	<li class="twitter">
-		<a href="https://twitter.com/share?url={{ uri|e('url') }}&amp;text={{ title|e('url') }}{% if not social.twitter.name is empty %}&amp;via={{ social.twitter.name }}{% endif %}">Twitter</a>
-	</li>
-	<li class="facebook">
-		<a href="http://www.facebook.com/sharer.php?s=100&amp;p[url]={{ uri|e('url') }}&amp;p[images][0]={{ imageUri|e('url') }}&amp;p[title]={{ title|e('url') }}&amp;p[summary]={{ description|raw|striptags|e('url') }}">Facebook</a>
-	</li>
+	{% if 'twitter' in networks %}
+		<li class="twitter">
+			<a href="https://twitter.com/share?url={{ uri|e('url') }}&amp;text={{ title|e('url') }}{% if not social.twitter.name is empty %}&amp;via={{ social.twitter.name }}{% endif %}">Twitter</a>
+		</li>
+	{% endif %}
+	{% if 'facebook' in networks %}
+		<li class="facebook">
+			<a href="http://www.facebook.com/sharer.php?s=100&amp;p[url]={{ uri|e('url') }}&amp;p[images][0]={{ imageUri|e('url') }}&amp;p[title]={{ title|e('url') }}&amp;p[summary]={{ description|raw|striptags|e('url') }}">Facebook</a>
+		</li>
+	{% endif %}
+	{% if 'pinterest' in networks %}
+		<li class="pinterest">
+			<a href="http://pinterest.com/pin/create/button/?url={{ uri|e('url') }}&amp;media={{ imageUri|e('url') }}&amp;description={{ description|raw|striptags|e('url') }}">Pinterest</a>
+		</li>
+	{% endif %}
+	{% if 'tumblr' in networks %}
+		<li class="tumblr">
+			<a href="http://www.tumblr.com/share/link?url=url={{ uri|e('url') }}&amp;description={{ description|raw|striptags|e('url') }}">Tumblr</a>
+		</li>
+	{% endif %}
 </ul>

--- a/src/Controller/Module/Social.php
+++ b/src/Controller/Module/Social.php
@@ -8,8 +8,12 @@ use Message\Cog\Filesystem\File;
 
 class Social extends Controller
 {
-	public function share(Page $page, $description = null, File $image = null, array $networks = ['facebook', 'twitter'])
+	public function share(Page $page, $description = null, File $image = null, array $networks = null)
 	{
+		if ($networks === null) {
+			$networks = ['facebook', 'twitter'];
+		}
+
 		$schemeAndHost = $this->get('http.request.master')->getSchemeAndHttpHost();
 		$trimmed       = rtrim($page->slug, '/');
 		$uri           = $schemeAndHost . $this->generateUrl('ms.cms.frontend', ['slug' => !empty($trimmed) ? $trimmed : $page->slug]);

--- a/src/Controller/Module/Social.php
+++ b/src/Controller/Module/Social.php
@@ -8,7 +8,7 @@ use Message\Cog\Filesystem\File;
 
 class Social extends Controller
 {
-	public function share(Page $page, $description = null, File $image = null, $networks = null)
+	public function share(Page $page, $description = null, File $image = null, array $networks = null)
 	{
 		if ($networks === null) {
 			$networks = ['facebook', 'twitter'];
@@ -28,9 +28,20 @@ class Social extends Controller
 		]);
 	}
 
-	public function links()
+	public function links(array $networks = null)
 	{
+		$cfg = $this->get('cfg')->social;
+
+		// if null then use all in the config
+		if ($networks === null) {
+			$networks = [];
+			foreach ($cfg as $network => $values) {
+				$networks[] = $network;
+			}
+		}
+
 		return $this->render('Message:Mothership:CMS::modules:social:links', [
+			'networks' => $networks,
 			'social' => $this->get('cfg')->social,
 		]);
 	}

--- a/src/Controller/Module/Social.php
+++ b/src/Controller/Module/Social.php
@@ -14,9 +14,10 @@ class Social extends Controller
 			$networks = ['facebook', 'twitter'];
 		}
 
-		$schemeAndHost = $this->get('http.request.master')->getSchemeAndHttpHost();
-		$trimmed       = rtrim($page->slug, '/');
-		$uri           = $schemeAndHost . $this->generateUrl('ms.cms.frontend', ['slug' => !empty($trimmed) ? $trimmed : $page->slug]);
+		$schemeAndHost = rtrim($this->get('http.request.master')->getSchemeAndHttpHost(), '/');
+		// empty breaks so homepage in this case
+		$slug = empty($page->slug) ? '/' : $page->slug;
+		$uri  = $schemeAndHost . '/' . trim($this->generateUrl('ms.cms.frontend', ['slug' => $slug]), '/');
 	
 		return $this->render('Message:Mothership:CMS::modules:social:share', [
 			'social'      => $this->get('cfg')->social,

--- a/src/Controller/Module/Social.php
+++ b/src/Controller/Module/Social.php
@@ -8,12 +8,8 @@ use Message\Cog\Filesystem\File;
 
 class Social extends Controller
 {
-	public function share(Page $page, $description = null, File $image = null, array $networks = null)
+	public function share(Page $page, $description = null, File $image = null, array $networks = ['facebook', 'twitter'])
 	{
-		if ($networks === null) {
-			$networks = ['facebook', 'twitter'];
-		}
-
 		$schemeAndHost = $this->get('http.request.master')->getSchemeAndHttpHost();
 		$trimmed       = rtrim($page->slug, '/');
 		$uri           = $schemeAndHost . $this->generateUrl('ms.cms.frontend', ['slug' => !empty($trimmed) ? $trimmed : $page->slug]);

--- a/src/Controller/Module/Social.php
+++ b/src/Controller/Module/Social.php
@@ -8,8 +8,12 @@ use Message\Cog\Filesystem\File;
 
 class Social extends Controller
 {
-	public function share(Page $page, $description = null, File $image = null)
+	public function share(Page $page, $description = null, File $image = null, $networks = null)
 	{
+		if ($networks === null) {
+			$networks = ['facebook', 'twitter'];
+		}
+
 		$schemeAndHost = $this->get('http.request.master')->getSchemeAndHttpHost();
 		$trimmed       = rtrim($page->slug, '/');
 		$uri           = $schemeAndHost . $this->generateUrl('ms.cms.frontend', ['slug' => !empty($trimmed) ? $trimmed : $page->slug]);
@@ -20,6 +24,7 @@ class Social extends Controller
 			'title'       => $page->metaTitle ?: $page->title,
 			'description' => $description ?: $page->metaDescription,
 			'imageUri'    => $image ? $schemeAndHost . $image->getUrl() : null,
+			'networks'    => $networks,
 		]);
 	}
 

--- a/src/Page/Loader.php
+++ b/src/Page/Loader.php
@@ -849,7 +849,6 @@ class Loader
 				unset($pages[$key]);
 				continue;
 			}
-
 		}
 
 		return count($pages) == 1 && !$this->_returnAsArray ? array_shift($pages) : $pages;


### PR DESCRIPTION
This adds a social link for Tumblr and Share links for both Tumblr and Pinterest as well as a way to specify which share links to display. The shown share links defaults to Twitter and Facebook to preserve BC.

To test try calling
```
{{
    render(controller('Message:Mothership:CMS::Controller:Module:Social#share', {
        page: page,
        networks: ['facebook', 'twitter', 'pinterest', 'tumblr']
    }))
}}
```
and checking the links that come out.

Also test the tumblr link.