### PR TITLE
Page edit access bug

### DIFF
--- a/src/Controller/ControlPanel/Edit.php
+++ b/src/Controller/ControlPanel/Edit.php
@@ -236,11 +236,16 @@ class Edit extends \Message\Cog\Controller\Controller
 				$page = $this->_updateSlug($page, $data['slug']);
 			}
 
+			$userGroups = $this->get('user.groups');
+
 			$page->visibilitySearch     = $data['visibility_search'];
 			$page->visibilityMenu       = $data['visibility_menu'];
 			$page->visibilityAggregator = $data['visibility_aggregator'];
 			$page->access               = $data['access'] ?: 0;
-			$page->accessGroups         = $data['access_groups'];
+			
+			$page->accessGroups               = array_map(function($x) use ($userGroups) {
+				return $userGroups->get($x);
+			}, $data['access_groups']);
 			$page->setTags($this->_parseTags($data['tags']));
 
 			$page = $this->get('cms.page.edit')->save($page);

--- a/src/Controller/ControlPanel/Edit.php
+++ b/src/Controller/ControlPanel/Edit.php
@@ -243,7 +243,7 @@ class Edit extends \Message\Cog\Controller\Controller
 			$page->visibilityAggregator = $data['visibility_aggregator'];
 			$page->access               = $data['access'] ?: 0;
 			
-			$page->accessGroups               = array_map(function($x) use ($userGroups) {
+			$page->accessGroups = array_map(function($x) use ($userGroups) {
 				return $userGroups->get($x);
 			}, $data['access_groups']);
 			$page->setTags($this->_parseTags($data['tags']));

--- a/src/Controller/ControlPanel/Edit.php
+++ b/src/Controller/ControlPanel/Edit.php
@@ -243,9 +243,10 @@ class Edit extends \Message\Cog\Controller\Controller
 			$page->visibilityAggregator = $data['visibility_aggregator'];
 			$page->access               = $data['access'] ?: 0;
 			
-			$page->accessGroups = array_map(function($x) use ($userGroups) {
-				return $userGroups->get($x);
+			$page->accessGroups = array_map(function($group) use ($userGroups) {
+				return $userGroups->get($group);
 			}, $data['access_groups']);
+
 			$page->setTags($this->_parseTags($data['tags']));
 
 			$page = $this->get('cms.page.edit')->save($page);

--- a/src/Page/Edit.php
+++ b/src/Page/Edit.php
@@ -127,7 +127,6 @@ class Edit implements TransactionalInterface
 		if (!$this->_transOverride) {
 			$this->_transaction->commit();
 		}
-
 		return $event->getPage();
 	}
 
@@ -380,10 +379,10 @@ class Edit implements TransactionalInterface
 		// Build the insert query and parameters
 		$inserts = array();
 		$values = array();
-		foreach ($page->accessGroups as $groupName) {
+		foreach ($page->accessGroups as $group) {
 			$inserts[] = '(?i, ?s)';
 			$values[] = $page->id;
-			$values[] = $groupName;
+			$values[] = $group->getName();
 		}
 
 		// If there is changes to be made then run the built query


### PR DESCRIPTION
### What
When editing a page attributes, the access groups were being set as strings. In all other cases where the page is being saved (content etc) the access groups are access objects. This is how the Loader loads them and how they should be. The Edit class was also expecting the attributes to be of type string (as that is what the action was passing it) therefore calling save() on a page without changing the array of access objects to an array of strings would break on the access query (cannot cast object to string).

### Testing
To test try changing the title of a page which has access groups set. Try setting and unsetting access groups.