### PR TITLE
Added getTagsFromChildren() method to TagLoader

### DIFF
--- a/src/Page/TagLoader.php
+++ b/src/Page/TagLoader.php
@@ -59,6 +59,25 @@ class TagLoader implements EntityLoaderInterface
 	}
 
 	/**
+	 * Get all tags that belong to child pages of the given page
+	 *
+	 * @param Page $parent    The parent page whose children's tags will be loaded
+	 *
+	 * @return array
+	 */
+	public function getTagsFromChildren(Page $parent)
+	{
+		return $this->_getQueryBuilder()
+			->leftJoin('page', 'page.page_id = page_tag.page_id')
+			->where('page.position_left > ?i', [$parent->left])
+			->where('page.position_right < ?i', [$parent->right])
+			->getQuery()
+			->run()
+			->flatten()
+		;
+	}
+
+	/**
 	 * @return \Message\Cog\DB\QueryBuilder
 	 */
 	private function _getQueryBuilder()

--- a/src/Page/TagLoader.php
+++ b/src/Page/TagLoader.php
@@ -101,7 +101,8 @@ class TagLoader implements EntityLoaderInterface
 
 		if (!$includeUnpublished) {
 			$queryBuilder->where('page.publish_at <= ?d', [new DateTimeImmutable]);
-			$queryBuilder->where('(page.unpublish_at > ?d OR page.unpublish_at IS NULL)', [new DateTimeImmutable]);		}
+			$queryBuilder->where('(page.unpublish_at > ?d OR page.unpublish_at IS NULL)', [new DateTimeImmutable]);
+		}
 
 		if (!$includeDeleted) {
 			$queryBuilder->where('page.deleted_at IS NULL');


### PR DESCRIPTION
This PR adds a method that allows us to load tags for any children of a given page, specifically to be used when filtering by tag