### PR TITLE
Feature/page order none

### DIFF
--- a/src/Page/Loader.php
+++ b/src/Page/Loader.php
@@ -677,8 +677,11 @@ class Loader
 				])
 				->from('page')
 				->leftJoin('page_access_group', 'page_access_group.page_id = page.page_id')
-				->groupBy('page.page_id')
-				->orderBy($this->_getOrderStatement());
+				->groupBy('page.page_id');
+
+			if (!$this->_order === PageOrder::NONE) {
+				$this->_queryBuilder->orderBy($this->_getOrderStatement())
+			}
 
 			if (!$this->_loadDeleted) {
 				$this->_queryBuilder->where('page.deleted_at IS NULL');

--- a/src/Page/Loader.php
+++ b/src/Page/Loader.php
@@ -679,7 +679,7 @@ class Loader
 				->leftJoin('page_access_group', 'page_access_group.page_id = page.page_id')
 				->groupBy('page.page_id');
 
-			if (!$this->_order === PageOrder::NONE) {
+			if ($this->_order !== PageOrder::NONE) {
 				$this->_queryBuilder->orderBy($this->_getOrderStatement());
 			}
 

--- a/src/Page/Loader.php
+++ b/src/Page/Loader.php
@@ -680,7 +680,7 @@ class Loader
 				->groupBy('page.page_id');
 
 			if (!$this->_order === PageOrder::NONE) {
-				$this->_queryBuilder->orderBy($this->_getOrderStatement())
+				$this->_queryBuilder->orderBy($this->_getOrderStatement());
 			}
 
 			if (!$this->_loadDeleted) {

--- a/src/Page/PageOrder.php
+++ b/src/Page/PageOrder.php
@@ -18,4 +18,5 @@ class PageOrder
 	const ID_REVERSE           = "cms.page.order.id.reverse";
 	const STANDARD             = "cms.page.order.standard";
 	const REVERSE              = "cms.page.order.reverse";
+	const NONE                 = "cms.page.order.none";
 }


### PR DESCRIPTION
This allows page ordering to be disabled by calling `->orderBy(PageOrder::NONE)`. This is sometimes required as in a QueryBuilder, running `orderBy()` twice does not remove the first order statement.

Test by calling `->orderBy(PageOrder::NONE)` on the page loader.