### PR TITLE
Set pagination count query if loader returns early

### DIFF
--- a/src/Page/Loader.php
+++ b/src/Page/Loader.php
@@ -160,6 +160,10 @@ class Loader
 	public function getByID($pageIDs)
 	{
 		if (!is_numeric($pageIDs) && empty($pageIDs)) {
+			if ($this->_pagination !== null) {
+				$this->_pagination->setCountQuery('SELECT 0 as `count`');
+			}
+
 			return is_array($pageIDs) ? [] : false;
 		}
 


### PR DESCRIPTION
See issue #269 for a description of the problem.

Test by calling something like this in a controller:

```php
$pagination = $this->get('pagination');
$loader = $this->get('cms.page.loader')->setPagination($pagination);
$loader->getByID([]);
$pagination->getCount();
```

Prior to the changes, there would be a horrid exception thrown.