### PR TITLE
Set tag loader on page proxy to include unpublished and deleted

### DIFF
--- a/src/Page/PageProxy.php
+++ b/src/Page/PageProxy.php
@@ -23,7 +23,7 @@ class PageProxy extends Page
 	public function getTags()
 	{
 		if (!$this->_isLoaded('tags')) {
-			$tags = $this->_loaders->get('tags')->load($this);
+			$tags = $this->_loaders->get('tags')->load($this, true, true);
 			
 			if ($tags !== false) {
 				$this->tags = $this->tags + $tags;


### PR DESCRIPTION
Tags weren't appearing in the attributes tab for unpublished pages, meaning that it looked like they weren't saving even though they were. This PR sets tags to always load if via a page proxy, regardless of whether the page is unpublished or deleted.