### PR TITLE
Frontend redirects to homepage properly

### DIFF
--- a/src/Controller/Frontend.php
+++ b/src/Controller/Frontend.php
@@ -57,9 +57,9 @@ class Frontend extends Controller
 		if (!$page) {
 			// Check for this slug in the history, and redirect if we find a result
 			if ($redirectTo = $this->get('cms.page.loader')->checkSlugHistory($slug)) {
-				return $this->redirect($this->generateUrl('ms.cms.frontend', array(
-					'slug' => ltrim($redirectTo->slug->getFull(), '/'),
-				)), 301);
+				return $this->redirect($this->generateUrl('ms.cms.frontend', [
+					'slug' => $redirectTo->isHomepage() ? '/' : ltrim($redirectTo->slug->getFull(), '/'),
+				]), 301);
 			}
 
 			// Otherwise, throw a 404


### PR DESCRIPTION
If the homepage is redirected to via slug_history, it was breaking due to redirecting to an empty slug. To fix this it now should redirect to '/' if it is the homepage.

Try adding a redirect to a homepage and going there. It should redirect properly.