### PR TITLE
Added the page cache to PageLoader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 4.6.0
+
+- Implemented page caching on `Page\Loader`
+- Optimised `Link` field type page tree building
+- Added `PageCollection` class for storing page cache
+- Added `cms.page.cache` service which returns `PageCollection` class
+- Increased `Cog` dependency to 4.8
+
 ## 4.5.3
 
 - Resolve issue where slug redirects would break if redirecting to the home page (where a slug is empty)

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 	"require": {
 		"php": ">=5.4.0",
 
-		"mothership-ec/cog"                         : "~4.4",
+		"mothership-ec/cog"                         : "~4.8",
 		"mothership-ec/cog-mothership-user"         : "~4.0",
 		"mothership-ec/cog-imageresize"             : "~2.0",
 		"mothership-ec/cog-mothership-cp"           : "~3.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "e49a92b36375f9aeb7f7f0e19651a8d6",
+    "hash": "239cd7493e87a4a00d9ab57f37097a4a",
     "packages": [
         {
             "name": "dflydev/markdown",
@@ -626,16 +626,16 @@
         },
         {
             "name": "mothership-ec/cog",
-            "version": "4.7.1",
+            "version": "4.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mothership-ec/cog.git",
-                "reference": "324e0c02cd30696b70cf1befe582f9db24faf34e"
+                "reference": "7b63eccebf4e0dcf40ad4b9bcc2716253367f8b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mothership-ec/cog/zipball/324e0c02cd30696b70cf1befe582f9db24faf34e",
-                "reference": "324e0c02cd30696b70cf1befe582f9db24faf34e",
+                "url": "https://api.github.com/repos/mothership-ec/cog/zipball/7b63eccebf4e0dcf40ad4b9bcc2716253367f8b8",
+                "reference": "7b63eccebf4e0dcf40ad4b9bcc2716253367f8b8",
                 "shasum": ""
             },
             "require": {
@@ -717,7 +717,7 @@
                 "cog",
                 "framework"
             ],
-            "time": "2015-07-31 12:57:18"
+            "time": "2015-08-18 13:35:50"
         },
         {
             "name": "mothership-ec/cog-imageresize",
@@ -971,16 +971,16 @@
         },
         {
             "name": "mothership-ec/cog-user",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mothership-ec/cog-user.git",
-                "reference": "9392dfdc39fbb2b58298076ddc855143c5db3851"
+                "reference": "48d8655c3fb5004b676a9294031be20ea9ab7cef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mothership-ec/cog-user/zipball/9392dfdc39fbb2b58298076ddc855143c5db3851",
-                "reference": "9392dfdc39fbb2b58298076ddc855143c5db3851",
+                "url": "https://api.github.com/repos/mothership-ec/cog-user/zipball/48d8655c3fb5004b676a9294031be20ea9ab7cef",
+                "reference": "48d8655c3fb5004b676a9294031be20ea9ab7cef",
                 "shasum": ""
             },
             "require": {
@@ -1013,7 +1013,7 @@
                 "cog",
                 "user"
             ],
-            "time": "2015-07-30 10:59:36"
+            "time": "2015-08-14 10:13:05"
         },
         {
             "name": "mtdowling/cron-expression",

--- a/src/Bootstrap/Services.php
+++ b/src/Bootstrap/Services.php
@@ -40,9 +40,14 @@ class Services implements ServicesInterface
 					'content' => $c['cms.page.content_loader'],
 					'image' => $c['cms.page.image.loader'],
 					'tags' => $c['cms.page.tag.loader'],
-				])
+				]),
+				$c['cms.page.cache']
 			);
 		});
+
+		$services['cms.page.cache'] = function($c) {
+			return new CMS\Page\PageCollection;
+		};
 
 		$services['cms.page.searcher'] = function($c) {
 			$searcher =  new CMS\Page\Searcher($c['db.query'], $c['markdown.parser']);

--- a/src/FieldType/Link.php
+++ b/src/FieldType/Link.php
@@ -264,14 +264,9 @@ class Link extends MultipleValueField
 	 *
 	 * @param Page $parent
 	 */
-	protected function _setPageHeirarchy(Page $parent = null)
+	protected function _setPageHeirarchy()
 	{
-		$children = $this->_loader->getChildren($parent);
-
-		foreach ($children as $page) {
-			$this->_pages[$page->id] = $page;
-			$this->_setPageHeirarchy($page);
-		}
+		$this->_pages = $this->_loader->getAll();
 	}
 
 	/**

--- a/src/FieldType/Link.php
+++ b/src/FieldType/Link.php
@@ -23,7 +23,6 @@ class Link extends MultipleValueField
 
 	const SCOPE_CMS      = 'cms';
 	const SCOPE_EXTERNAL = 'external';
-//	const SCOPE_ROUTE    = 'route'; # for a future version?
 	const SCOPE_ANY      = 'any';
 
 	const DEFAULT_LABEL = 'ms.cms.field_types.link.default_label';
@@ -58,6 +57,8 @@ class Link extends MultipleValueField
 
 	public function getFormField(FormBuilder $form)
 	{
+		$this->_setDefaultOptions();
+
 		switch ($this->_scope) {
 			case self::SCOPE_CMS :
 				$this->_addCmsLink($form);
@@ -83,7 +84,6 @@ class Link extends MultipleValueField
 		}
 
 		$this->_scope = $scope;
-		$this->_setDefaultOptions();
 
 		return $this;
 	}
@@ -138,7 +138,7 @@ class Link extends MultipleValueField
 	 * @return Link
 	 */
 	public function setFieldOptions(array $options)
-	{
+	{		
 		$base = $this->getFieldOptions();
 
 		$options = array_merge($base, $options);
@@ -211,18 +211,25 @@ class Link extends MultipleValueField
 	 */
 	protected function _setCmsLinkOptions()
 	{
-		$this->_setPageHeirarchy();
-		$options = [];
+		if(empty($this->getFieldOptions()['choices'])) {
+			$this->_setPageHeirarchy();
+			$options = [];
 
-		foreach ($this->_pages as $page) {
-			$prefix             = str_repeat('-', $page->depth);
-			$options[$page->id] = $prefix . ' ' . $page->title;
+			foreach ($this->_pages as $page) {
+				$prefix             = str_repeat('-', $page->depth);
+				$options[$page->id] = $prefix . ' ' . $page->title;
+			}
+
+			$this->setFieldOptions([
+				'choices'     => $options,
+			]);
 		}
 
-		$this->setFieldOptions([
-			'empty_value' => self::EMPTY_VALUE,
-			'choices'     => $options,
-		]);
+		if(!empty($this->getFieldOptions()['choices'])) {
+			$this->setFieldOptions([
+				'empty_value' => self::EMPTY_VALUE,
+			]);
+		}
 	}
 
 	/**
@@ -238,16 +245,18 @@ class Link extends MultipleValueField
 	 */
 	protected function _setAnyLinkOptions()
 	{
-		$this->_setPageHeirarchy();
-		$options = [];
+		if(empty($this->getFieldOptions()['choices'])) {
+			$this->_setPageHeirarchy();
+			$options = [];
 
-		foreach ($this->_pages as $page) {
-			$options[] = $page->slug->getFull();
+			foreach ($this->_pages as $page) {
+				$options[] = $page->slug->getFull();
+			}
+
+			$this->setFieldOptions([
+				'choices'  => $options,
+			]);
 		}
-
-		$this->setFieldOptions([
-			'choices'  => $options,
-		]);
 	}
 
 	/**

--- a/src/Page/Loader.php
+++ b/src/Page/Loader.php
@@ -828,7 +828,7 @@ class Loader
 			// If the page is set to inherit it's access then loop through each
 			// parent to find the inherited access level.
 			// Check to see if this has already been loaded first (from cache)
-			if (!isset($pages[$key]->access)) {
+			if (!isset($pages[$key]->access) || $pages[$key]->access < 0) {
 				$pages[$key]->accessInherited = false;
 				$check = $pages[$key];
 

--- a/src/Page/Loader.php
+++ b/src/Page/Loader.php
@@ -17,6 +17,7 @@ use Message\Cog\DB\QueryBuilderInterface;
 use Message\Cog\Filter\FilterCollection;
 use Message\Cog\Pagination\Pagination;
 use Message\Cog\DB\Entity\EntityLoaderCollection;
+use Message\Cog\ValueObject\Collection;
 
 /**
  * Responsible for loading page data and returning prepared instances of `Page`.
@@ -118,6 +119,11 @@ class Loader
 	private $_filters;
 
 	/**
+	 * @var Collection
+	 */
+	private $_pageCache;
+
+	/**
 	 * Constructor
 	 *
 	 * @param QueryBuilderFactory    $queryBuilderFactory   Database query instance to use
@@ -136,7 +142,8 @@ class Loader
 		Authorisation $authorisation,
 		UserInterface $user,
 		Searcher $searcher,
-		EntityLoaderCollection $loaders
+		EntityLoaderCollection $loaders,
+		Collection $pageCache
 	) {
 		$this->_queryBuilderFactory  = $queryBuilderFactory;
 		$this->_pageTypes            = $pageTypes;
@@ -145,6 +152,7 @@ class Loader
 		$this->_user 		         = $user;
 		$this->_searcher             = $searcher;
 		$this->_loaders              = $loaders;
+		$this->_pageCache            = $pageCache;
 	}
 
 	/**
@@ -758,18 +766,20 @@ class Loader
 	{
 		$results = $this->_runQuery();
 
+		foreach ($results as $key => $data) {
+			if ($this->_pageCache->exists($key)) {
+
+			}
+		}
+
 		$pages = $results->bindTo(
 			'Message\\Mothership\\CMS\\Page\\PageProxy',
-			[$this->_loaders]
+			[$this->_loaders],
+			false,
+			$this->_pageCache
 		);
 
 		foreach ($results as $key => $data) {
-			// Skip deleted pages
-			if ($data->deletedAt && !$this->_loadDeleted) {
-				unset($pages[$key]);
-				continue;
-			}
-
 			$pages[$key]->visibilitySearch     = (bool) $pages[$key]->visibilitySearch;
 			$pages[$key]->visibilityMenu       = (bool) $pages[$key]->visibilityMenu;
 			$pages[$key]->visibilityAggregator = (bool) $pages[$key]->visibilityAggregator;
@@ -780,13 +790,6 @@ class Loader
 				$data->unpublishAt ? new DateTimeImmutable(date('c', $data->unpublishAt)) : null
 			);
 
-			// Remove the page if we are asking to not show unpublished pages and
-			// the page is in fact unpublished
-			if (!$this->_loadUnpublished && !$this->_authorisation->isPublished($pages[$key])) {
-				unset($pages[$key]);
-				continue;
-			}
-
 			// Get the page type
 			$pages[$key]->type = $this->_pageTypes->get($data->type);
 
@@ -796,59 +799,73 @@ class Loader
 				$data->slug = new Slug('/');
 			}
 
-			$pages[$key]->slug = new Slug($data->slug);
-			$pages[$key]->type = clone $this->_pageTypes->get($data->type);
-
-			// Load authorship details
-			$pages[$key]->authorship = new Authorship;
-			$pages[$key]->authorship->create(new DateTimeImmutable(date('c',$data->createdAt)), $data->createdBy);
-
-			if ($data->updatedAt) {
-				$pages[$key]->authorship->update(new DateTimeImmutable(date('c',$data->updatedAt)), $data->updatedBy);
+			
+			// Test if already set from cache before loading
+			if (!isset($pages[$key]->slug)) {
+				$pages[$key]->slug = new Slug($data->slug);
 			}
 
-			if ($data->deletedAt) {
-				$pages[$key]->authorship->delete(new DateTimeImmutable(date('c',$data->deletedAt)), $data->deletedBy);
+			// Test if already set from cache before loading
+			if (!isset($pages[$key]->type)) {
+				$pages[$key]->type = clone $this->_pageTypes->get($data->type);
+			}
+
+			// Load authorship details
+			// Test if already set from cache before loading
+			if (!isset($pages[$key]->authorship)) {
+				$pages[$key]->authorship = new Authorship;
+				$pages[$key]->authorship->create(new DateTimeImmutable(date('c',$data->createdAt)), $data->createdBy);
+
+				if ($data->updatedAt) {
+					$pages[$key]->authorship->update(new DateTimeImmutable(date('c',$data->updatedAt)), $data->updatedBy);
+				}
+
+				if ($data->deletedAt) {
+					$pages[$key]->authorship->delete(new DateTimeImmutable(date('c',$data->deletedAt)), $data->deletedBy);
+				}
 			}
 
 			// If the page is set to inherit it's access then loop through each
 			// parent to find the inherited access level.
-			$pages[$key]->accessInherited = false;
-			$check = $pages[$key];
+			// Check to see if this has already been loaded first (from cache)
+			if (!isset($pages[$key]->access)) {
+				$pages[$key]->accessInherited = false;
+				$check = $pages[$key];
 
-			while ($pages[$key]->access < 0) {
-				$check = $this->_queryBuilderFactory->getQueryBuilder()
-					->select([
-						'access',
-						'GROUP_CONCAT(page_access_group.group_name SEPARATOR \',\') AS accessGroups'
-					])
-					->from('page')
-					->leftJoin('page_access_group', 'page_access_group.page_id = page.page_id')
-					->where('page.position_left < ?i', [$check->left])
-					->where('page.position_right >= ?i', [$check->left])
-					->where('page.position_depth = ?i - 1', [$check->depth])
-					->getQuery()
-					->run()
-				;
+				while ($pages[$key]->access < 0) {
+					$check = $this->_queryBuilderFactory->getQueryBuilder()
+						->select([
+							'access',
+							'GROUP_CONCAT(page_access_group.group_name SEPARATOR \',\') AS accessGroups'
+						])
+						->from('page')
+						->leftJoin('page_access_group', 'page_access_group.page_id = page.page_id')
+						->where('page.position_left < ?i', [$check->left])
+						->where('page.position_right >= ?i', [$check->left])
+						->where('page.position_depth = ?i - 1', [$check->depth])
+						->getQuery()
+						->run()
+					;
 
-				$check = $check->bindTo('Message\\Mothership\\CMS\\Page\\Page');
-				$check = $check[0];
+					$check = $check->bindTo('Message\\Mothership\\CMS\\Page\\Page');
+					$check = $check[0];
 
-				$pages[$key]->access = $check->access;
-				$data->accessGroups = $check->accessGroups;
+					$pages[$key]->access = $check->access;
+					$data->accessGroups = $check->accessGroups;
 
-				$pages[$key]->accessInherited = true;
-			}
+					$pages[$key]->accessInherited = true;
+				}
 
-			// Ensure the page access is at least 0
-			$pages[$key]->access = max(0, $pages[$key]->access);
+				// Ensure the page access is at least 0
+				$pages[$key]->access = max(0, $pages[$key]->access);
 
-			// Load access groups
-			$groups = array_filter(explode(',', $data->accessGroups));
-			$pages[$key]->accessGroups = array();
-			foreach ($groups as $groupName) {
-				if ($group = $this->_userGroups->get(trim($groupName))) {
-					$pages[$key]->accessGroups[$group->getName()] = $group;
+				// Load access groups
+				$groups = array_filter(explode(',', $data->accessGroups));
+				$pages[$key]->accessGroups = array();
+				foreach ($groups as $groupName) {
+					if ($group = $this->_userGroups->get(trim($groupName))) {
+						$pages[$key]->accessGroups[$group->getName()] = $group;
+					}
 				}
 			}
 

--- a/src/Page/Loader.php
+++ b/src/Page/Loader.php
@@ -793,15 +793,15 @@ class Loader
 			// Get the page type
 			$pages[$key]->type = $this->_pageTypes->get($data->type);
 
-			// If the page is the most left page then it is the homepage so
-			// we need to override the slug to avoid unnecessary redirects
-			if ($this->_getMinPositionLeft() == $data->left) {
-				$data->slug = new Slug('/');
-			}
+			if (!isset($pages[$key]->slug) || !($pages[$key]->slug instanceof Slug)) {
+				// If the page is the most left page then it is the homepage so
+				// we need to override the slug to avoid unnecessary redirects
+				if ($this->_getMinPositionLeft() == $data->left) {
+					$data->slug = new Slug('/');
+				}
 
 			
-			// Test if already set from cache before loading
-			if (!isset($pages[$key]->slug)) {
+				// Test if already set from cache before loading
 				$pages[$key]->slug = new Slug($data->slug);
 			}
 

--- a/src/Page/PageCollection.php
+++ b/src/Page/PageCollection.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Message\Mothership\CMS\Page;
+
+use Message\Cog\ValueObject\Collection;
+
+class PageCollection extends Collection
+{
+	protected function _configure()
+	{
+		$this->setType('\\Message\\Mothership\\CMS\\Page\\Page');
+		$this->setKey('id');
+	}
+}


### PR DESCRIPTION
This adds a PageCollection and the "cms.page.cache" service. This reduces the number of queries and memory usage by a lot in places where the pages are all loaded in multiple time (for instance when editing a PageType with multiple Link fields).

This requires https://github.com/mothership-ec/cog/pull/458.