### PR TITLE
Filters: Try to replace with the element rather than the whole screen

### DIFF
--- a/resources/assets/js/filter-pages.js
+++ b/resources/assets/js/filter-pages.js
@@ -168,7 +168,10 @@ function filterPages(ajaxUrl, filterDestinationID, method, formID, paginationMen
 			type: submitMethod,
 			data: form.serialize(),
 			success: function (data) {
-				filterDestination.html(data);
+				var replace = $(filterDestinationID, data);
+				replace = replace.size() ? replace : $(data); 
+
+				filterDestination.html(replace);
 				appendFormDataToPagination();
 				appendFormDataToAddressUrl();
 			}


### PR DESCRIPTION
This allows users to define an ajax filter using `filterPages('{{ page.slug }}', '#product-listing');`, no extra routes required. It tests to see if the listing element exists within the result, and if so, just uses that element. Otherwise it uses the whole response.

This means that the route can be set to the current pages slug to use the current location. Test on with the extra route way as well as the page route way to check for BC breaks. 