### PR TITLE
Replace filters with children of replcement element

### DIFF
--- a/resources/assets/js/filter-pages.js
+++ b/resources/assets/js/filter-pages.js
@@ -169,7 +169,7 @@ function filterPages(ajaxUrl, filterDestinationID, method, formID, paginationMen
 			data: form.serialize(),
 			success: function (data) {
 				var replace = $(filterDestinationID, data);
-				replace = replace.size() ? replace : $(data); 
+				replace = replace.size() ? replace.children() : $(data); 
 
 				filterDestination.html(replace);
 				appendFormDataToPagination();


### PR DESCRIPTION
This replaces the inner of the filter element with the inner of the new filter element rather than replacing the inner of the element with the entire new element. This is to avoid duplicate nested filter elements.