### PR TITLE
Added a better test to see if access is loaded

### DIFF
--- a/src/Page/Loader.php
+++ b/src/Page/Loader.php
@@ -828,7 +828,7 @@ class Loader
 			// If the page is set to inherit it's access then loop through each
 			// parent to find the inherited access level.
 			// Check to see if this has already been loaded first (from cache)
-			if (!isset($pages[$key]->access) || $pages[$key]->access < 0) {
+			if (!isset($pages[$key]->access) || !is_array($pages[$key]->access)) {
 				$pages[$key]->accessInherited = false;
 				$check = $pages[$key];
 


### PR DESCRIPTION
Page access groups were not loading on properly and we kept getting an error on the attributes page. This tests the access to see if it's set to an array.

Make sure this makes that error goes away.