### PR TITLE
Add contentevent and dispatch it on content edit

### DIFF
--- a/src/Page/ContentEdit.php
+++ b/src/Page/ContentEdit.php
@@ -102,6 +102,11 @@ class ContentEdit
 			'pageID'    => $page->id,
 		]);
 
+		$this->_dispatcher->dispatch(
+			Event\ContentEvent::EDIT,
+			new Event\ContentEvent($page, $content)
+		);
+
 		return $this->_transaction->commit();
 	}
 

--- a/src/Page/Event/ContentEvent.php
+++ b/src/Page/Event/ContentEvent.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Message\Mothership\CMS\Page\Event;
+
+use Message\Mothership\CMS\Page;
+
+class ContentEvent extends Event
+{
+	const EDIT = 'cms.page.content.edit';
+	const CREATE = 'cms.page.content.create';
+
+	private $_content;
+
+	public function __construct(Page\Page $page, Page\Content $content)
+	{
+		$this->_content = $content;
+
+		parent::__construct($page);
+	}
+
+	public function setContent(Page\Content $content)
+	{
+		$this->_content = $content;
+	}
+
+	public function getContent()
+	{
+		return $this->_content;
+	}
+}


### PR DESCRIPTION
This PR ensures that an event is fired upon page load. It extends the Page event so it can also be used by methods that use them