### PR TITLE
Added `isPublished()` method, do not include deleted pages on link field

### DIFF
--- a/src/FieldType/Link.php
+++ b/src/FieldType/Link.php
@@ -218,6 +218,10 @@ class Link extends MultipleValueField
 			foreach ($this->_pages as $page) {
 				$prefix             = str_repeat('-', $page->depth);
 				$options[$page->id] = $prefix . ' ' . $page->title;
+
+				if (!$page->isPublished()) {
+					$options[$page->id] .= ' [unpublished]';
+				}
 			}
 
 			$this->setFieldOptions([
@@ -266,7 +270,7 @@ class Link extends MultipleValueField
 	 */
 	protected function _setPageHeirarchy()
 	{
-		$this->_pages = $this->_loader->getAll();
+		$this->_pages = $this->_loader->includeDeleted(false)->getAll();
 	}
 
 	/**

--- a/src/Page/Page.php
+++ b/src/Page/Page.php
@@ -109,6 +109,20 @@ class Page
 	}
 
 	/**
+	 * Check to see if the current time falls within the publish date range
+	 *
+	 * @return bool
+	 */
+	public function isPublished()
+	{
+		if (null === $this->publishDateRange) {
+			return false;
+		}
+
+		return $this->publishDateRange->isInRange();
+	}
+
+	/**
 	 * Check if the page is the homepage.
 	 *
 	 * @return boolean


### PR DESCRIPTION
This PR adds an `isPublished()` method to the page object, and prevents deleted pages from showing up in the link field. It also marks unpublished pages as unpublished when using the link field in CMS mode