### PR TITLE
Do not include unpublished or deleted page in content filters

### DIFF
--- a/src/Page/Filter/ContentFilter.php
+++ b/src/Page/Filter/ContentFilter.php
@@ -95,9 +95,14 @@ class ContentFilter extends AbstractContentFilter
 		}
 
 		$queryBuilder = $this->_queryBuilderFactory->getQueryBuilder()
-			->select('value_string', true)
+			->select('page_content.value_string', true)
 			->from('page_content')
-			->where('field_name = ?s', [$this->_field]);
+			->join('page', 'page_content.page_id = page.page_id')
+			->where('page_content.field_name = ?s', [$this->_field])
+			->where('page.deleted_at IS NULL')
+			->where('page.publish_at <= UNIX_TIMESTAMP()')
+			->where('(page.unpublish_at IS NULL OR page.unpublish_at > UNIX_TIMESTAMP())')
+		;
 
 		if (null !== $this->_group) {
 			$queryBuilder->where('group_name = ?s', [$this->_group]);


### PR DESCRIPTION
This PR prevents content filters from loading content from deleted or unpublished pages when setting the choices. This could be perceived as a behavioural change but I'm willing to call the original behaviour as a bug as I can't see any reason why you would this data to be loaded into the choices, so don't think it's worth making it a configurable