### PR TITLE
Fixed loadFromFilter() on page loader

### DIFF
--- a/src/Page/Loader.php
+++ b/src/Page/Loader.php
@@ -620,13 +620,13 @@ class Loader
 	 *
 	 * @param FilterCollection $filters
 	 *
-	 * @return array|Page
+	 * @return array
 	 */
 	public function loadFromFilters(FilterCollection $filters)
 	{
 		$this->applyFilters($filters);
 
-		return $this->_loadPages();
+		return $this->getAll();
 	}
 
 	/**


### PR DESCRIPTION
Fixes the loadFromFilters method. It was throwing an exception as the _buildQuery method had not been run.

Test this function with some filters.