### PR TITLE
Refactor slug updating

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 	"require": {
 		"php": ">=5.4.0",
 
-		"mothership-ec/cog"                         : "~4.8",
+		"mothership-ec/cog"                         : "dev-feature/translation-exception as 4.13.0",
 		"mothership-ec/cog-mothership-user"         : "~4.0",
 		"mothership-ec/cog-imageresize"             : "~2.0",
 		"mothership-ec/cog-mothership-cp"           : "~3.3",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 	"require": {
 		"php": ">=5.4.0",
 
-		"mothership-ec/cog"                         : "dev-feature/translation-exception as 4.13.0",
+		"mothership-ec/cog"                         : "~4.13",
 		"mothership-ec/cog-mothership-user"         : "~4.0",
 		"mothership-ec/cog-imageresize"             : "~2.0",
 		"mothership-ec/cog-mothership-cp"           : "~3.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "239cd7493e87a4a00d9ab57f37097a4a",
+    "hash": "a0e913655c0fce12f9fdfe4ad979fde0",
     "packages": [
         {
             "name": "dflydev/markdown",
@@ -626,16 +626,16 @@
         },
         {
             "name": "mothership-ec/cog",
-            "version": "4.12.0",
+            "version": "dev-feature/translation-exception",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mothership-ec/cog.git",
-                "reference": "46c1473effe92997d8459ad137a3304d1b7e50da"
+                "reference": "c2c2b45599d64022f6e668283d3537b5aa6d4fd6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mothership-ec/cog/zipball/46c1473effe92997d8459ad137a3304d1b7e50da",
-                "reference": "46c1473effe92997d8459ad137a3304d1b7e50da",
+                "url": "https://api.github.com/repos/mothership-ec/cog/zipball/c2c2b45599d64022f6e668283d3537b5aa6d4fd6",
+                "reference": "c2c2b45599d64022f6e668283d3537b5aa6d4fd6",
                 "shasum": ""
             },
             "require": {
@@ -717,7 +717,7 @@
                 "cog",
                 "framework"
             ],
-            "time": "2015-10-02 16:40:49"
+            "time": "2015-10-07 16:47:47"
         },
         {
             "name": "mothership-ec/cog-imageresize",
@@ -872,16 +872,16 @@
         },
         {
             "name": "mothership-ec/cog-mothership-reports",
-            "version": "2.1.0",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mothership-ec/cog-mothership-reports.git",
-                "reference": "08509152a97a468e4fb250cebe6cad3c7745096f"
+                "reference": "f1a6fe7556b0072e41a34c292f1c99c710730091"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mothership-ec/cog-mothership-reports/zipball/08509152a97a468e4fb250cebe6cad3c7745096f",
-                "reference": "08509152a97a468e4fb250cebe6cad3c7745096f",
+                "url": "https://api.github.com/repos/mothership-ec/cog-mothership-reports/zipball/f1a6fe7556b0072e41a34c292f1c99c710730091",
+                "reference": "f1a6fe7556b0072e41a34c292f1c99c710730091",
                 "shasum": ""
             },
             "require": {
@@ -916,7 +916,7 @@
                 "reports",
                 "stats"
             ],
-            "time": "2015-09-28 13:33:50"
+            "time": "2015-10-07 09:50:19"
         },
         {
             "name": "mothership-ec/cog-mothership-user",
@@ -2560,9 +2560,18 @@
         }
     ],
     "packages-dev": [],
-    "aliases": [],
+    "aliases": [
+        {
+            "alias": "4.13.0",
+            "alias_normalized": "4.13.0.0",
+            "version": "dev-feature/translation-exception",
+            "package": "mothership-ec/cog"
+        }
+    ],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "mothership-ec/cog": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "a0e913655c0fce12f9fdfe4ad979fde0",
+    "hash": "acccfcb41e3fd9d8b08afd3eda53449d",
     "packages": [
         {
             "name": "dflydev/markdown",
@@ -626,16 +626,16 @@
         },
         {
             "name": "mothership-ec/cog",
-            "version": "dev-feature/translation-exception",
+            "version": "4.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mothership-ec/cog.git",
-                "reference": "c2c2b45599d64022f6e668283d3537b5aa6d4fd6"
+                "reference": "d569d3401103454dca8615d75c0fea68694a759f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mothership-ec/cog/zipball/c2c2b45599d64022f6e668283d3537b5aa6d4fd6",
-                "reference": "c2c2b45599d64022f6e668283d3537b5aa6d4fd6",
+                "url": "https://api.github.com/repos/mothership-ec/cog/zipball/d569d3401103454dca8615d75c0fea68694a759f",
+                "reference": "d569d3401103454dca8615d75c0fea68694a759f",
                 "shasum": ""
             },
             "require": {
@@ -717,7 +717,7 @@
                 "cog",
                 "framework"
             ],
-            "time": "2015-10-07 16:47:47"
+            "time": "2015-10-09 16:31:08"
         },
         {
             "name": "mothership-ec/cog-imageresize",
@@ -769,16 +769,16 @@
         },
         {
             "name": "mothership-ec/cog-mothership-cp",
-            "version": "3.5.0",
+            "version": "3.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mothership-ec/cog-mothership-cp.git",
-                "reference": "e3ba65f3c213ff4a1a708e6f1ba06d00ef69b29c"
+                "reference": "a135ec49577f504d67d8fa0161e293821f93ed0a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mothership-ec/cog-mothership-cp/zipball/e3ba65f3c213ff4a1a708e6f1ba06d00ef69b29c",
-                "reference": "e3ba65f3c213ff4a1a708e6f1ba06d00ef69b29c",
+                "url": "https://api.github.com/repos/mothership-ec/cog-mothership-cp/zipball/a135ec49577f504d67d8fa0161e293821f93ed0a",
+                "reference": "a135ec49577f504d67d8fa0161e293821f93ed0a",
                 "shasum": ""
             },
             "require": {
@@ -815,7 +815,7 @@
                 "control panel",
                 "mothership"
             ],
-            "time": "2015-09-23 13:51:53"
+            "time": "2015-10-08 12:48:19"
         },
         {
             "name": "mothership-ec/cog-mothership-file-manager",
@@ -920,16 +920,16 @@
         },
         {
             "name": "mothership-ec/cog-mothership-user",
-            "version": "4.2.1",
+            "version": "4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mothership-ec/cog-mothership-user.git",
-                "reference": "1f146f6a3e8f585383631a2ddc8f71317719359f"
+                "reference": "4cde8112673b228189d9456ad2e270b455a255c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mothership-ec/cog-mothership-user/zipball/1f146f6a3e8f585383631a2ddc8f71317719359f",
-                "reference": "1f146f6a3e8f585383631a2ddc8f71317719359f",
+                "url": "https://api.github.com/repos/mothership-ec/cog-mothership-user/zipball/4cde8112673b228189d9456ad2e270b455a255c0",
+                "reference": "4cde8112673b228189d9456ad2e270b455a255c0",
                 "shasum": ""
             },
             "require": {
@@ -937,7 +937,7 @@
                 "mothership-ec/cog": "~4.9",
                 "mothership-ec/cog-mothership-cp": "~3.0",
                 "mothership-ec/cog-mothership-file-manager": "~3.0",
-                "mothership-ec/cog-mothership-reports": "~2.0",
+                "mothership-ec/cog-mothership-reports": "~2.2",
                 "mothership-ec/cog-user": "~2.0",
                 "php": ">=5.4.0"
             },
@@ -967,7 +967,7 @@
                 "mothership",
                 "user"
             ],
-            "time": "2015-09-16 10:45:17"
+            "time": "2015-10-08 13:14:09"
         },
         {
             "name": "mothership-ec/cog-user",
@@ -2560,18 +2560,9 @@
         }
     ],
     "packages-dev": [],
-    "aliases": [
-        {
-            "alias": "4.13.0",
-            "alias_normalized": "4.13.0.0",
-            "version": "dev-feature/translation-exception",
-            "package": "mothership-ec/cog"
-        }
-    ],
+    "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "mothership-ec/cog": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/src/Bootstrap/Services.php
+++ b/src/Bootstrap/Services.php
@@ -187,6 +187,15 @@ class Services implements ServicesInterface
 			return $fields;
 		});
 
+		$services['cms.page.slug_edit'] = function ($c) {
+			return new CMS\Page\SlugEdit(
+				$c['cms.page.loader'],
+				$c['cms.page.edit'],
+				$c['routing.matcher'],
+				$c['routing.generator']
+			);
+		};
+
 		$services->extend('form.extensions', function($extensions, $c) {
 			$extensions[] = $c['form.cms_extension'];
 

--- a/src/Controller/ControlPanel/Edit.php
+++ b/src/Controller/ControlPanel/Edit.php
@@ -9,6 +9,7 @@ use Message\Mothership\CMS\Page\Authorisation;
 use Message\Mothership\CMS\Page\Page;
 use Message\Mothership\CMS\Page\Content;
 use Message\Mothership\CMS\Page\Exception\PageEditException;
+use Message\Mothership\CMS\Page\Exception\SlugUpdateException;
 
 use Message\Cog\ValueObject\Slug;
 use Message\Mothership\FileManager\File;
@@ -555,101 +556,12 @@ class Edit extends \Message\Cog\Controller\Controller
 	 */
 	protected function _updateSlug(Page $page, Slug $slug)
 	{
-		$newSlug = $slug->getLastSegment();
-
-		// Flag as to whether to update the slug
-		$update = true;
-
-		$slugSegments = $page->slug->getSegments();
-		$last  = array_pop($slugSegments);
-		$slugSegments[] = $newSlug;
-		$slug = '/'.implode('/',$slugSegments);
-		$checkSlug = $this->get('cms.page.loader')->getBySlug($slug, false);
-
 		try {
-			$routes = $this->get('routing.matcher')->match($slug);
-
-			// continue if the frontend route is the most prominent
-			if ($routes['_route'] !== 'ms.cms.frontend') {
-				$this->addFlash('error',  $this->trans('ms.cms.feedback.force-slug.failure.reserved-route'));
-				$update = false;
-			}
-		} catch (\Symfony\Component\Routing\Exception\ResourceNotFoundException $e) {	
-			$this->addFlash('error', $this->trans('ms.cms.feedback.force-slug.failure.not-matched'));
-			$update = false;
+			$this->get('cms.page.slug_edit')->updateSlug($page, $slug);
+		} catch (SlugUpdateException $e) {
+			$this->addFlash('error', $e->getTranslation(), $e->getParams());
 		}
 
-		// If not slug has been found, we need to check the history too
-		if (!$checkSlug && $update) {
-			// Check for the slug historically and show deleted ones too
-			$historicalSlug = $this->get('cms.page.loader')
-				->includeDeleted(true)
-				->getBySlug($slug, true);
-
-			// If there is a page returned and it's not this page then offer
-			// a link to remove the slug from history and use it anyway
-			if ($historicalSlug && $historicalSlug->id != $page->id) {
-				// If it's been deleted then offer a different message that a non deleted one
-				if (!is_null($historicalSlug->authorship->deletedAt())) {
-					$this->addFlash(
-						'error',
-						$this->trans(
-							'ms.cms.feedback.force-slug.failure.deleted',
-							array(
-								'%slug%' => $slug,
-								'%forceUrl%' => $this->generateUrl('ms.cp.cms.edit.attributes.slug.force', array('pageID' => $page->id,'slug' => $newSlug))
-							)
-						)
-					);
-				} else {
-					$this->addFlash(
-						'error',
-						$this->trans(
-							'ms.cms.feedback.force-slug.failure.redirected',
-							array(
-								'%slug%' => $slug,
-								'%redirectedUrl%' => $this->generateUrl('ms.cp.cms.edit.attributes', array('pageID' => $historicalSlug->id)),
-								'%redirectedTitle%' => $historicalSlug->title,
-								'%forceUrl%' => $this->generateUrl('ms.cp.cms.edit.attributes.slug.force', array('pageID' => $page->id,'slug' => $newSlug)),
-							)
-						)
-					);
-				}
-
-				// We shouldn't update the slug as we need action
-				$update = false;
-			}
-		}
-
-		if ($checkSlug && $checkSlug->id != $page->id) {
-			$this->addFlash(
-				'error',
-				$this->trans(
-					'ms.cms.feedback.force-slug.failure.already-used',
-					array(
-						'%slugUrl%' => $checkSlug->slug->getFull(),
-						'%usingUrl%' => $this->generateUrl('ms.cp.cms.edit.attributes', array('pageID' => $checkSlug->id)),
-						'%usingTitle%' => $checkSlug->title,
-					)
-				)
-			);
-			// We shouldn't update the slug as we need action
-			$update = false;
-		}
-
-		// If the slug has changed then update the slug
-		if ($update && $page->slug->getLastSegment() != $newSlug) {
-			$this->get('cms.page.edit')->removeHistoricalSlug($slug);
-			try {
-				$page = $this->get('cms.page.edit')->updateSlug($page, $newSlug);
-			} catch (InvalidSlugException $e) {
-				$this->addFlash('error', $this->trans('ms.cms.feedback.force-slug.failure.generic', [
-					'%message%' => $e->getMessage(),
-				]));
-			}
-		}
-
-		// return the updated or unchanged page
 		return $page;
 	}
 

--- a/src/Controller/ControlPanel/Edit.php
+++ b/src/Controller/ControlPanel/Edit.php
@@ -187,7 +187,7 @@ class Edit extends \Message\Cog\Controller\Controller
 		$fullSlug = '/'.implode('/',$slugSegments);
 
 		$this->get('cms.page.edit')->removeHistoricalSlug($fullSlug);
-		$page = $this->_updateSlug($page, new Slug($slug));
+		$page = $this->_updateSlug($page, new Slug($slugSegments));
 		$this->addFlash('success', $this->trans('ms.cms.feedback.force-slug.success'));
 
 		return $this->redirectToReferer();
@@ -569,7 +569,7 @@ class Edit extends \Message\Cog\Controller\Controller
 		try {
 			$routes = $this->get('routing.matcher')->match($slug);
 
-			// continue if the frontend route is the most promenant
+			// continue if the frontend route is the most prominent
 			if ($routes['_route'] !== 'ms.cms.frontend') {
 				$this->addFlash('error',  $this->trans('ms.cms.feedback.force-slug.failure.reserved-route'));
 				$update = false;
@@ -581,7 +581,7 @@ class Edit extends \Message\Cog\Controller\Controller
 
 		// If not slug has been found, we need to check the history too
 		if (!$checkSlug && $update) {
-			// Check for the slug historicaly and show deleted ones too
+			// Check for the slug historically and show deleted ones too
 			$historicalSlug = $this->get('cms.page.loader')
 				->includeDeleted(true)
 				->getBySlug($slug, true);
@@ -589,7 +589,7 @@ class Edit extends \Message\Cog\Controller\Controller
 			// If there is a page returned and it's not this page then offer
 			// a link to remove the slug from history and use it anyway
 			if ($historicalSlug && $historicalSlug->id != $page->id) {
-				// If it's been deleted then offer a differnt message that a non deleted one
+				// If it's been deleted then offer a different message that a non deleted one
 				if (!is_null($historicalSlug->authorship->deletedAt())) {
 					$this->addFlash(
 						'error',

--- a/src/Page/Edit.php
+++ b/src/Page/Edit.php
@@ -146,8 +146,8 @@ class Edit implements TransactionalInterface
 			throw new Exception\InvalidSlugException('Slug must only be formed of alphanumeric characters and hyphens.');
 		}
 
-		// Get all the segements
-		$segements = $page->slug->getSegments();
+		// Get all the segments
+		$segments = $page->slug->getSegments();
 		$date = new DateTimeImmutable;
 
 		$this->_transaction->run('
@@ -179,7 +179,7 @@ class Edit implements TransactionalInterface
 			)
 		);
 		// Remove the last one
-		$last = array_pop($segements);
+		$last = array_pop($segments);
 		// Set the new one to the end of the array
 		$segments[] = $newSlug;
 		// Create a new slug object

--- a/src/Page/Exception/SlugUpdateException.php
+++ b/src/Page/Exception/SlugUpdateException.php
@@ -4,6 +4,15 @@ namespace Message\Mothership\CMS\Page\Exception;
 
 use Message\Cog\Exception\TranslationLogicException;
 
+/**
+ * Class SlugUpdateException
+ * @package Message\Mothership\CMS\Page\Exception
+ *
+ * @author  Thomas Marchant <thomas@mothership.ec>
+ *
+ * Exception to be thrown when a slug cannot be updated. Extends TranslationLogicException so
+ * error messages can be relayed to the user via a flash message.
+ */
 class SlugUpdateException extends TranslationLogicException
 {
 

--- a/src/Page/Exception/SlugUpdateException.php
+++ b/src/Page/Exception/SlugUpdateException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Message\Mothership\CMS\Page\Exception;
+
+use Message\Cog\Exception\TranslationLogicException;
+
+class SlugUpdateException extends TranslationLogicException
+{
+
+}

--- a/src/Page/Loader.php
+++ b/src/Page/Loader.php
@@ -464,6 +464,8 @@ class Loader
 			->where('page.position_depth = ?i', [count($parts)])
 		;
 
+		d($this->_queryBuilder->getQueryString());
+
 		$pages = $this->_loadPages();
 
 		if ($pages) {

--- a/src/Page/Loader.php
+++ b/src/Page/Loader.php
@@ -464,8 +464,6 @@ class Loader
 			->where('page.position_depth = ?i', [count($parts)])
 		;
 
-		d($this->_queryBuilder->getQueryString());
-
 		$pages = $this->_loadPages();
 
 		if ($pages) {

--- a/src/Page/SlugEdit.php
+++ b/src/Page/SlugEdit.php
@@ -63,11 +63,11 @@ class SlugEdit
 	 */
 	public function updateSlug(Page $page, Slug $slug)
 	{
-		$newSlug = $slug->getLastSegment();
-
-		if ($newSlug === $page->slug->getLastSegment()) {
+		if ($slug->getFull() === $page->slug->getFull()) {
 			return;
 		}
+
+		$newSlug = $slug->getLastSegment();
 
 		$slugSegments = $page->slug->getSegments();
 		array_pop($slugSegments);
@@ -75,22 +75,20 @@ class SlugEdit
 		$slug = '/'.implode('/',$slugSegments);
 
 		$this->_checkRoute($slug);
-		$this->_checkSlugExists($page, $newSlug, $slug);
+		$this->_checkSlugExists($page, $slug);
 
 		// If the slug has changed then update the slug
-		if ($page->slug->getLastSegment() != $newSlug) {
-			$this->_pageEdit->removeHistoricalSlug($slug);
-			try {
-				$this->_pageEdit->updateSlug($page, $newSlug);
-			} catch (Exception\InvalidSlugException $e) {
-				throw new Exception\SlugUpdateException(
-					$e->getMessage(),
-					'ms.cms.feedback.force-slug.failure.generic',
-					[
-						'%message%' => $e->getMessage(),
-					]
-				);
-			}
+		$this->_pageEdit->removeHistoricalSlug($slug);
+		try {
+			$this->_pageEdit->updateSlug($page, $newSlug);
+		} catch (Exception\InvalidSlugException $e) {
+			throw new Exception\SlugUpdateException(
+				$e->getMessage(),
+				'ms.cms.feedback.force-slug.failure.generic',
+				[
+					'%message%' => $e->getMessage(),
+				]
+			);
 		}
 	}
 

--- a/src/Page/SlugEdit.php
+++ b/src/Page/SlugEdit.php
@@ -6,13 +6,42 @@ use Message\Cog\ValueObject\Slug;
 use Message\Cog\Routing\UrlMatcher;
 use Message\Cog\Routing\UrlGenerator;
 
+use Symfony\Component\Routing\Exception\ResourceNotFoundException;
+
+/**
+ * Class SlugEdit
+ * @package Message\Mothership\CMS\Page
+ *
+ * @author  Thomas Marchant <thomas@mothership.ec>
+ */
 class SlugEdit
 {
+	/**
+	 * @var Loader
+	 */
 	private $_pageLoader;
+
+	/**
+	 * @var Edit
+	 */
 	private $_pageEdit;
+
+	/**
+	 * @var UrlMatcher
+	 */
 	private $_urlMatcher;
+
+	/**
+	 * @var UrlGenerator
+	 */
 	private $_urlGenerator;
 
+	/**
+	 * @param Loader $pageLoader
+	 * @param Edit $pageEdit
+	 * @param UrlMatcher $urlMatcher
+	 * @param UrlGenerator $urlGenerator
+	 */
 	public function __construct(
 		Loader $pageLoader,
 		Edit $pageEdit,
@@ -26,71 +55,27 @@ class SlugEdit
 		$this->_urlGenerator = $urlGenerator;
 	}
 
-	public function updateSlug(Page $page, Slug $slug, $force = false)
+	/**
+	 * Check that a slug can be updated for a page and update if so
+	 *
+	 * @param Page $page
+	 * @param Slug $slug
+	 */
+	public function updateSlug(Page $page, Slug $slug)
 	{
 		$newSlug = $slug->getLastSegment();
+
+		if ($newSlug === $page->slug->getLastSegment()) {
+			return;
+		}
 
 		$slugSegments = $page->slug->getSegments();
 		array_pop($slugSegments);
 		$slugSegments[] = $newSlug;
 		$slug = '/'.implode('/',$slugSegments);
-		$checkSlug = $this->_pageLoader->getBySlug($slug, false);
 
-		try {
-			$routes = $this->_urlMatcher->match($slug);
-
-			// continue if the frontend route is the most prominent
-			if ($routes['_route'] !== 'ms.cms.frontend') {
-				throw new Exception\SlugUpdateException(
-					'`' . $slug . '` cannot be set as it conflicts with an existing route',
-					'ms.cms.feedback.force-slug.failure.reserved-route'
-				);
-			}
-		} catch (\Symfony\Component\Routing\Exception\ResourceNotFoundException $e) {
-			throw new Exception\SlugUpdateException(
-				$e->getMessage(),
-				'ms.cms.feedback.force-slug.failure.not-matched'
-			);
-		}
-
-		// If not slug has been found, we need to check the history too
-		if (!$checkSlug) {
-			// Check for the slug historically and show deleted ones too
-			$historicalSlug = $this->_pageLoader
-				->getBySlug($slug, true);
-
-			// If there is a page returned and it's not this page then offer
-			// a link to remove the slug from history and use it anyway
-			if ($historicalSlug && $historicalSlug->id != $page->id) {
-				throw new Exception\SlugUpdateException(
-					'Slug `' . $slug . '` has been previously and is redirecting to page ' . $historicalSlug->id,
-					'ms.cms.feedback.force-slug.failure.redirected',
-					[
-						'%slug%' => $slug,
-						'%redirectedUrl%' => $this->_urlGenerator->generate(
-							'ms.cp.cms.edit.attributes',
-							['pageID' => $historicalSlug->id]
-						),
-						'%redirectedTitle%' => $historicalSlug->title,
-						'%forceUrl%' => $this->_urlGenerator->generate(
-							'ms.cp.cms.edit.attributes.slug.force', ['pageID' => $page->id, 'slug' => $newSlug]
-						),
-					]
-				);
-			}
-		}
-
-		if ($checkSlug && $checkSlug->id != $page->id) {
-			throw new Exception\SlugUpdateException(
-				'Slug `' . $slug . '` has is already used',
-				'ms.cms.feedback.force-slug.failure.already-used',
-				[
-					'%slugUrl%' => $checkSlug->slug->getFull(),
-					'%usingUrl%' => $this->_urlGenerator->generate('ms.cp.cms.edit.attributes', ['pageID' => $checkSlug->id]),
-					'%usingTitle%' => $checkSlug->title,
-				]
-			);
-		}
+		$this->_checkRoute($slug);
+		$this->_checkSlugExists($page, $newSlug, $slug);
 
 		// If the slug has changed then update the slug
 		if ($page->slug->getLastSegment() != $newSlug) {
@@ -106,6 +91,114 @@ class SlugEdit
 					]
 				);
 			}
+		}
+	}
+
+	/**
+	 * Check that no route matching the slug exists
+	 *
+	 * @param string $slug
+	 * @throws \InvalidArgumentException        Throws exception if $slug is not a string
+	 * @throws Exception\SlugUpdateException    Throws exception if route exists matching slug
+	 * @throws Exception\SlugUpdateException    Rethrows exception if a ResourceNotFoundException is caught
+	 */
+	private function _checkRoute($slug)
+	{
+		if (!is_string($slug)) {
+			throw new \InvalidArgumentException('Slug must be a string, ' . gettype($slug) . ' given');
+		}
+
+		try {
+			$routes = $this->_urlMatcher->match($slug);
+
+			// continue if the frontend route is the most prominent
+			if ($routes['_route'] !== 'ms.cms.frontend') {
+				throw new Exception\SlugUpdateException(
+					'`' . $slug . '` cannot be set as it conflicts with an existing route',
+					'ms.cms.feedback.force-slug.failure.reserved-route'
+				);
+			}
+		} catch (ResourceNotFoundException $e) {
+			throw new Exception\SlugUpdateException(
+				$e->getMessage(),
+				'ms.cms.feedback.force-slug.failure.not-matched'
+			);
+		}
+	}
+
+	/**
+	 * Check that a no page exists with this slug
+	 *
+	 * @param Page $page
+	 * @param $slug
+	 * @throws \InvalidArgumentException        Throws exception if $slug is not a string
+	 * @throws Exception\SlugUpdateException    Throws exception if page exists with slug matching that given
+	 *                                          in $slug
+	 */
+	private function _checkSlugExists(Page $page, $slug)
+	{
+		if (!is_string($slug)) {
+			throw new \InvalidArgumentException('Slug must be a string, ' . gettype($slug) . ' given');
+		}
+
+		$existingPage = $this->_pageLoader->getBySlug($slug, false);
+
+		if ($existingPage && $existingPage->id != $page->id) {
+			throw new Exception\SlugUpdateException(
+				'Slug `' . $slug . '` has is already used',
+				'ms.cms.feedback.force-slug.failure.already-used',
+				[
+					'%slugUrl%' => $existingPage->slug->getFull(),
+					'%usingUrl%' => $this->_urlGenerator->generate('ms.cp.cms.edit.attributes', ['pageID' => $existingPage->id]),
+					'%usingTitle%' => $existingPage->title,
+				]
+			);
+		} elseif (!$existingPage) {
+			$this->_checkSlugHistory($page, $slug);
+		}
+	}
+
+	/**
+	 * Check that a no page exists with this slug in its history
+	 *
+	 * @param Page $page
+	 * @param $slug
+	 * @throws \InvalidArgumentException        Throws exception if $slug is not a string
+	 * @throws Exception\SlugUpdateException    Throws exception if page exists with slug matching that given
+	 *                                          in $slug in its slug history
+	 */
+	private function _checkSlugHistory(Page $page, $slug)
+	{
+		if (!is_string($slug)) {
+			throw new \InvalidArgumentException('Slug must be a string, ' . gettype($slug) . ' given');
+		}
+
+		// Check for the slug historically and show deleted ones too
+		$historicalSlug = $this->_pageLoader
+			->getBySlug($slug, true);
+
+		// If there is a page returned and it's not this page then offer
+		// a link to remove the slug from history and use it anyway
+		if ($historicalSlug && $historicalSlug->id != $page->id) {
+
+			$slugParts = explode('/', $slug);
+			$newSlug = array_pop($slugParts);
+
+			throw new Exception\SlugUpdateException(
+				'Slug `' . $slug . '` has been previously and is redirecting to page ' . $historicalSlug->id,
+				'ms.cms.feedback.force-slug.failure.redirected',
+				[
+					'%slug%' => $slug,
+					'%redirectedUrl%' => $this->_urlGenerator->generate(
+						'ms.cp.cms.edit.attributes',
+						['pageID' => $historicalSlug->id]
+					),
+					'%redirectedTitle%' => $historicalSlug->title,
+					'%forceUrl%' => $this->_urlGenerator->generate(
+						'ms.cp.cms.edit.attributes.slug.force', ['pageID' => $page->id, 'slug' => $newSlug]
+					),
+				]
+			);
 		}
 	}
 

--- a/src/Page/SlugEdit.php
+++ b/src/Page/SlugEdit.php
@@ -143,7 +143,7 @@ class SlugEdit
 
 		if ($existingPage && $existingPage->id != $page->id) {
 			throw new Exception\SlugUpdateException(
-				'Slug `' . $slug . '` has is already used',
+				'Slug `' . $slug . '` has already been used',
 				'ms.cms.feedback.force-slug.failure.already-used',
 				[
 					'%slugUrl%' => $existingPage->slug->getFull(),
@@ -183,7 +183,7 @@ class SlugEdit
 			$newSlug = array_pop($slugParts);
 
 			throw new Exception\SlugUpdateException(
-				'Slug `' . $slug . '` has been previously and is redirecting to page ' . $historicalSlug->id,
+				'Slug `' . $slug . '` has been used previously and is redirecting to page ' . $historicalSlug->id,
 				'ms.cms.feedback.force-slug.failure.redirected',
 				[
 					'%slug%' => $slug,

--- a/src/Page/SlugEdit.php
+++ b/src/Page/SlugEdit.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Message\Mothership\CMS\Page;
+
+use Message\Cog\ValueObject\Slug;
+use Message\Cog\Routing\UrlMatcher;
+
+class SlugEdit
+{
+	private $_pageLoader;
+	private $_pageEdit;
+	private $_urlMatcher;
+
+	public function __construct(
+		Loader $pageLoader,
+		Edit $pageEdit,
+		UrlMatcher $urlMatcher
+	)
+	{
+		$this->_pageLoader = $pageLoader;
+		$this->_pageEdit = $pageEdit;
+		$this->_urlMatcher = $urlMatcher;
+	}
+
+	public function updateSlug(Page $page, Slug $slug)
+	{
+		$newSlug = $slug->getLastSegment();
+
+		$slugSegments = $page->slug->getSegments();
+		array_pop($slugSegments);
+		$slugSegments[] = $newSlug;
+		$slug = '/'.implode('/',$slugSegments);
+		$checkSlug = $this->_pageLoader->getBySlug($slug, false);
+
+		try {
+			$routes = $this->_urlMatcher->match($slug);
+
+			// continue if the frontend route is the most prominent
+			if ($routes['_route'] !== 'ms.cms.frontend') {
+				throw new Exception\SlugUpdateException(
+					'`' . $slug . '` cannot be set as it conflicts with an existing route',
+					'ms.cms.feedback.force-slug.failure.reserved-route'
+				);
+			}
+		} catch (\Symfony\Component\Routing\Exception\ResourceNotFoundException $e) {
+			throw new Exception\SlugUpdateException(
+				$e->getMessage(),
+				'ms.cms.feedback.force-slug.failure.not-matched'
+			);
+		}
+
+		// If not slug has been found, we need to check the history too
+		if (!$checkSlug) {
+			// Check for the slug historically and show deleted ones too
+			$historicalSlug = $this->_pageLoader
+				->includeDeleted(true)
+				->getBySlug($slug, true);
+
+			// If there is a page returned and it's not this page then offer
+			// a link to remove the slug from history and use it anyway
+			if ($historicalSlug && $historicalSlug->id != $page->id) {
+				// If it's been deleted then offer a different message that a non deleted one
+				if (!is_null($historicalSlug->authorship->deletedAt())) {
+					throw new Exception\SlugUpdateException(
+						'Slug `' . $slug . '` has been previously used on a deleted page',
+						'ms.cms.feedback.force-slug.failure.deleted',
+						[
+							'%slug%' => $slug,
+							'%forceUrl%' => $this->generateUrl('ms.cp.cms.edit.attributes.slug.force', array('pageID' => $page->id,'slug' => $newSlug))
+						]
+					);
+				} else {
+					throw new Exception\SlugUpdateException(
+						'Slug `' . $slug . '` has been previously and is redirecting to page ' . $historicalSlug->id,
+						'ms.cms.feedback.force-slug.failure.redirected',
+						[
+							'%slug%' => $slug,
+							'%redirectedUrl%' => $this->generateUrl('ms.cp.cms.edit.attributes', array('pageID' => $historicalSlug->id)),
+							'%redirectedTitle%' => $historicalSlug->title,
+							'%forceUrl%' => $this->generateUrl('ms.cp.cms.edit.attributes.slug.force', array('pageID' => $page->id,'slug' => $newSlug)),
+						]
+					);
+				}
+			}
+		}
+
+		if ($checkSlug && $checkSlug->id != $page->id) {
+			throw new Exception\SlugUpdateException(
+				'Slug `' . $slug . '` has is already used',
+				'ms.cms.feedback.force-slug.failure.already-used',
+				[
+					'%slugUrl%' => $checkSlug->slug->getFull(),
+					'%usingUrl%' => $this->generateUrl('ms.cp.cms.edit.attributes', array('pageID' => $checkSlug->id)),
+					'%usingTitle%' => $checkSlug->title,
+				]
+			);
+		}
+
+		// If the slug has changed then update the slug
+		if ($page->slug->getLastSegment() != $newSlug) {
+			$this->_pageEdit->removeHistoricalSlug($slug);
+			try {
+				$this->_pageEdit->updateSlug($page, $newSlug);
+			} catch (Exception\InvalidSlugException $e) {
+				throw new Exception\SlugUpdateException(
+					$e->getMessage(),
+					'ms.cms.feedback.force-slug.failure.generic',
+					[
+						'%message%' => $e->getMessage(),
+					]
+				);
+			}
+		}
+	}
+
+}

--- a/translations/en.yml
+++ b/translations/en.yml
@@ -40,7 +40,7 @@ ms.cms:
         reserved-route: This route is already reserved by a module.
         generic: Error updating slug: %message%
         not-matched: The slug given does not match the requirements. Please use only alphanumeric characters and hyphens.
-      success: The Url was successfully updated
+      success: The URL was successfully updated
   repeatable_group:
     add: "{0} Add a %name%|[1,Inf] Add another %name%"
     remove: Remove this %name%


### PR DESCRIPTION
This PR stabilises slug updating when editing a page.

Changes in this PR:

+ Moved slug update code from controller to new `Page\SlugEdit` class and split it out into methods
+ Added `Page\Exception\SlugUpdateException` which extends the new `TranslationLogicException` to send translation strings to the controller to render as flash messages
+ It is now possible to update slugs that are set against deleted pages without being informed

Requires https://github.com/mothership-ec/cog/pull/478