### PR TITLE
Deprecate HistoricalSlugExistsException, and remove from SlugGenerator

### DIFF
--- a/src/Exception/HistoricalSlugExistsException.php
+++ b/src/Exception/HistoricalSlugExistsException.php
@@ -11,6 +11,8 @@ use Message\Cog\ValueObject\Slug;
  * history for another page.
  *
  * @author Joe Holdcroft <joe@message.co.uk>
+ *
+ * @deprecated Exception is no longer in use, use \Message\Mothership\CMS\Page\Exception\SlugUpdateException instead
  */
 class HistoricalSlugExistsException extends Exception
 {

--- a/src/Page/SlugGenerator.php
+++ b/src/Page/SlugGenerator.php
@@ -52,9 +52,6 @@ class SlugGenerator
 	 *                            when called internally
 	 *
 	 * @return Slug               The generated slug instance
-	 *
-	 * @throws Exception\HistoricalSlugExistsException If the original generated
-	 *                                                 slug exists in the history
 	 */
 	public function generate($title, Page $parent = null, $attempt = 1)
 	{
@@ -73,15 +70,6 @@ class SlugGenerator
 
 		// Check to see if this slug exists in the history
 		$redirectPage = $this->_loader->checkSlugHistory($slug->getFull());
-
-		// If this slug exists in the history and this is the original
-		// generation request, throw special exception
-		if ($redirectPage && 1 === $attempt) {
-			throw new Exception\HistoricalSlugExistsException(sprintf(
-				'Slug `%s` exists historically',
-				$slug->getFull()
-			), $slug, $redirectPage);
-		}
 
 		// If the generated slug exists either historically or on a live page,
 		// try again with a flag for uniqueness


### PR DESCRIPTION
Saving pages with a name that would cause it to be generated with a historical slug would error. This exception is unnecessary I think and this feature hinders usability.

Currently this still appends a number to the end of the slug if it exists as a historical slug, do you think it should remove the existing slug or work in the same way as it does currently. I'm of the opinion that if a page has been renamed, we don't need to be too precious about its old slug,