### PR TITLE
Added email share link

### DIFF
--- a/resources/view/modules/social/share.html.twig
+++ b/resources/view/modules/social/share.html.twig
@@ -64,6 +64,14 @@
 				</a>
 			</li>
 
+		{% elseif network == 'email' %}
+
+			<li class="email">
+				<a href="mailto:?subject={{ title|e('url') }}&amp;body={{ description|raw|striptags|e('url') }}%20via%20{{ uri|e('url') }}">
+					Email
+				</a>
+			</li>
+
 		{% endif %}
 	{% endfor %}
 </ul>


### PR DESCRIPTION
Adds email share link. This doesn;t require any config setup, however to make it show, it must be called in the networks array.